### PR TITLE
Tests Operative Planung

### DIFF
--- a/reisewitz-test/01-stammdaten/01-accesspoint.md
+++ b/reisewitz-test/01-stammdaten/01-accesspoint.md
@@ -1,0 +1,77 @@
+# Testfall: Einstiegspunkt-Verwaltung
+
+## Zweck
+
+Verifiziert den vollständigen Lebenszyklus eines **Einstiegspunkts**
+(AccessPoint) — vom Anlegen über Lesen bis zum Löschen — sowie das
+korrekte Fehlerverhalten bei ungültigen oder nicht vorhandenen Daten.
+
+## Hintergrund
+
+Ein **Einstiegspunkt** ist ein fest definierter geografischer Ort,
+an dem Fahrgäste in das System ein- oder aussteigen können — etwa der
+Hauptbahnhof, eine Universität oder ein Stadtplatz. Er ist ein
+Stammdatenobjekt: einmal angelegt, ändert er sich im laufenden Betrieb
+selten.
+
+Jeder Einstiegspunkt besitzt:
+- eine eindeutige Kennung,
+- eine geografische Position (Breitengrad/Längengrad),
+- eine maximale Standzeit (wie lange ein Fahrzeug dort halten darf).
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet rund um Paderborn ist im System hinterlegt.
+- Es sind keine Fahrzeuge aktiv (leere Flotte), damit der Test nicht
+  durch laufende Fahrten beeinflusst wird.
+
+## Testfälle
+
+```gherkin
+Funktionalität: Verwaltung von Einstiegspunkten
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und es sind keine Fahrzeuge aktiv
+
+  Szenario: Einen neuen Einstiegspunkt anlegen
+    Wenn ein Einstiegspunkt mit einer eindeutigen Kennung
+         und einer gültigen Position angelegt wird
+    Dann bestätigt das System die Aufnahme erfolgreich
+
+  Szenario: Einen vorhandenen Einstiegspunkt einzeln lesen
+    Angenommen ein Einstiegspunkt mit der Kennung "ap-crud-test" wurde angelegt
+    Wenn dieser Einstiegspunkt über seine Kennung abgefragt wird
+    Dann liefert das System den Eintrag erfolgreich zurück
+
+  Szenario: Alle Einstiegspunkte als Liste lesen
+    Wenn die Liste aller Einstiegspunkte angefragt wird
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält die Liste aller bekannten Einstiegspunkte
+
+  Szenario: Einen Einstiegspunkt löschen
+    Angenommen ein Einstiegspunkt mit der Kennung "ap-crud-test" existiert
+    Wenn der Einstiegspunkt über seine Kennung gelöscht wird
+    Dann bestätigt das System die Löschung erfolgreich
+
+  Szenario: Einen gelöschten Einstiegspunkt erneut lesen
+    Angenommen der Einstiegspunkt "ap-crud-test" wurde soeben gelöscht
+    Wenn dieser Einstiegspunkt erneut über seine Kennung abgefragt wird
+    Dann meldet das System, dass der Eintrag nicht gefunden wurde
+
+  Szenario: Anlegen mit unvollständigen Daten ablehnen
+    Wenn ein Einstiegspunkt mit leerer Kennung und ohne Position angelegt
+         werden soll
+    Dann lehnt das System die Anfrage als ungültig ab
+
+  Szenario: Löschen einer nicht vorhandenen Kennung ablehnen
+    Wenn ein Einstiegspunkt mit der Kennung "ghost-id" gelöscht werden soll,
+         obwohl kein solcher Eintrag existiert
+    Dann meldet das System, dass der Eintrag nicht gefunden wurde
+```
+
+## Bemerkungen
+
+- Die Kennung ist frei wählbar, muss aber systemweit eindeutig sein.
+- Die Position muss innerhalb eines bekannten Betriebsgebiets liegen,
+  damit der Einstiegspunkt für Fahrtanfragen genutzt werden kann.

--- a/reisewitz-test/01-stammdaten/02-chaininglocation.md
+++ b/reisewitz-test/01-stammdaten/02-chaininglocation.md
@@ -1,0 +1,54 @@
+# Testfall: Kopplungsort-Verwaltung
+
+## Zweck
+
+Prüft den vollständigen Lebenszyklus von **Kopplungsorten**
+(ChainingLocations) — Orte, an denen ein Cab an ein Pro angekoppelt
+oder davon getrennt wird.
+
+## Hintergrund
+
+Ein **Kopplungsort** ist eine geografische Zone (definiert durch einen
+Start- und einen Endpunkt), in der ein **Cab** auf einen **Pro**
+auffahren oder von ihm herunterfahren kann. Damit lassen sich längere
+Strecken energieeffizient als Konvoi zurücklegen: das große
+Trägerfahrzeug (Pro) bringt das Personenfahrzeug (Cab) auf die
+Schnellstraße.
+
+Jeder Kopplungsort besitzt:
+- eine eindeutige Kennung,
+- einen Startpunkt und einen Endpunkt der Kopplungszone,
+- den erlaubten Vorgang (nur Ankoppeln, nur Abkoppeln, oder beides),
+- eine optionale zusätzliche Manöverzeit in Sekunden.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet ist im System hinterlegt.
+- Es sind keine Fahrzeuge aktiv.
+
+## Testfälle
+
+```gherkin
+Funktionalität: Verwaltung von Kopplungsorten
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und es sind keine Fahrzeuge aktiv
+
+  Szenario: Einen neuen Kopplungsort anlegen
+    Wenn ein Kopplungsort mit eindeutiger Kennung,
+         gültigem Start- und Endpunkt sowie zulässigem Vorgangstyp angelegt wird
+    Dann bestätigt das System die Aufnahme erfolgreich
+
+  Szenario: Anlegen mit unvollständigen Daten ablehnen
+    Wenn ein Kopplungsort mit leerer Kennung und ohne Start-/Endpunkt
+         angelegt werden soll
+    Dann lehnt das System die Anfrage als ungültig ab
+```
+
+## Bemerkungen
+
+- Der Vorgangstyp kann sein: nur Ankoppeln, nur Abkoppeln, oder
+  Ankoppeln und Abkoppeln am selben Ort.
+- Start- und Endpunkt definieren eine kurze Strecke, auf der das
+  Manöver stattfindet (z. B. Ein-/Ausfädelspur einer Schnellstraße).

--- a/reisewitz-test/01-stammdaten/02-chaininglocation.md
+++ b/reisewitz-test/01-stammdaten/02-chaininglocation.md
@@ -3,22 +3,23 @@
 ## Zweck
 
 Prüft den vollständigen Lebenszyklus von **Kopplungsorten**
-(ChainingLocations) — Orte, an denen ein Cab an ein Pro angekoppelt
-oder davon getrennt wird.
+(ChainingLocations) — Orte, an denen ein Cab per Kupplung an ein Pro
+angehängt oder von ihm wieder gelöst wird.
 
 ## Hintergrund
 
 Ein **Kopplungsort** ist eine geografische Zone (definiert durch einen
-Start- und einen Endpunkt), in der ein **Cab** auf einen **Pro**
-auffahren oder von ihm herunterfahren kann. Damit lassen sich längere
-Strecken energieeffizient als Konvoi zurücklegen: das große
-Trägerfahrzeug (Pro) bringt das Personenfahrzeug (Cab) auf die
-Schnellstraße.
+Start- und einen Endpunkt), in der ein **Cab** per Kupplung an ein
+**Pro** angehängt oder wieder von ihm gelöst werden kann. So lassen
+sich längere Strecken als Verbund energieeffizient zurücklegen: das
+wasserstoffbetriebene Zugfahrzeug Pro zieht die angekuppelten Cabs,
+und die Cabs verbrauchen dabei keine eigene Akkukapazität — ihr Akku
+wird über die Kupplung sogar während der Fahrt nachgeladen.
 
 Jeder Kopplungsort besitzt:
 - eine eindeutige Kennung,
 - einen Startpunkt und einen Endpunkt der Kopplungszone,
-- den erlaubten Vorgang (nur Ankoppeln, nur Abkoppeln, oder beides),
+- den erlaubten Vorgang (nur Ankuppeln, nur Abkuppeln, oder beides),
 - eine optionale zusätzliche Manöverzeit in Sekunden.
 
 ## Voraussetzungen
@@ -48,7 +49,7 @@ Funktionalität: Verwaltung von Kopplungsorten
 
 ## Bemerkungen
 
-- Der Vorgangstyp kann sein: nur Ankoppeln, nur Abkoppeln, oder
-  Ankoppeln und Abkoppeln am selben Ort.
+- Der Vorgangstyp kann sein: nur Ankuppeln, nur Abkuppeln, oder
+  Ankuppeln und Abkuppeln am selben Ort.
 - Start- und Endpunkt definieren eine kurze Strecke, auf der das
-  Manöver stattfindet (z. B. Ein-/Ausfädelspur einer Schnellstraße).
+  Manöver stattfindet.

--- a/reisewitz-test/01-stammdaten/03-operationarea.md
+++ b/reisewitz-test/01-stammdaten/03-operationarea.md
@@ -1,0 +1,60 @@
+# Testfall: Betriebsgebiet-Verwaltung
+
+## Zweck
+
+Prüft den Lebenszyklus eines **Betriebsgebiets** (OperationArea) — der
+geografischen Zone, innerhalb derer das System Fahrten anbietet.
+
+## Hintergrund
+
+Ein **Betriebsgebiet** ist die Servicezone eines Betreibers, definiert
+durch ein **Polygon** aus mehreren Eckpunkten. Nur Fahrten mit Start
+und Ziel innerhalb dieses Polygons werden vom System geplant. Außerhalb
+liegende Fahrtanfragen werden mit der Information „außerhalb des
+Servicebereichs" abgewiesen.
+
+Jedes Betriebsgebiet besitzt:
+- eine eindeutige Kennung,
+- ein Polygon (Liste von Eckpunkten als Breitengrad/Längengrad-Paaren),
+- ein Gültigkeits-Zeitfenster mit Start- und Endzeitpunkt.
+
+## Voraussetzungen
+
+- Es sind keine Fahrzeuge aktiv.
+
+## Testfälle
+
+```gherkin
+Funktionalität: Verwaltung von Betriebsgebieten
+
+  Hintergrund:
+    Angenommen es sind keine Fahrzeuge aktiv
+
+  Szenario: Ein neues Betriebsgebiet anlegen
+    Wenn ein Betriebsgebiet mit eindeutiger Kennung,
+         einem geschlossenen Polygon (mindestens drei Eckpunkte) und einem
+         Gültigkeitszeitraum angelegt wird
+    Dann bestätigt das System die Aufnahme erfolgreich
+
+  Szenario: Ein vorhandenes Betriebsgebiet einzeln lesen
+    Angenommen ein Betriebsgebiet existiert
+    Wenn dieses Betriebsgebiet über seine Kennung abgefragt wird
+    Dann liefert das System den Eintrag erfolgreich zurück
+
+  Szenario: Ein Betriebsgebiet löschen
+    Angenommen ein Betriebsgebiet existiert
+    Wenn das Betriebsgebiet über seine Kennung gelöscht wird
+    Dann bestätigt das System die Löschung erfolgreich
+```
+
+## Bemerkungen
+
+- **Bekannte Einschränkung:** Die Schnittstelle für Betriebsgebiete
+  kennzeichnet aktuell den Status mit umgekehrter Logik gegenüber den
+  übrigen Stammdaten-Endpunkten: ein erfolgreich angelegtes Gebiet
+  wird unter Umständen mit einem Nicht-gefunden-Status quittiert,
+  während ein bereits existierendes Gebiet mit Erfolg gemeldet wird.
+  Dieser Test ist deshalb dauerhaft als bekannter Fehler markiert
+  und blockiert die anderen Testläufe nicht.
+- Das Polygon muss geschlossen sein (erster und letzter Eckpunkt
+  identisch) und sollte sich nicht selbst überschneiden.

--- a/reisewitz-test/01-stammdaten/04-parkinglocation.md
+++ b/reisewitz-test/01-stammdaten/04-parkinglocation.md
@@ -1,0 +1,50 @@
+# Testfall: Parkplatz-Verwaltung
+
+## Zweck
+
+Prüft den Lebenszyklus von **Parkplätzen** (ParkingLocations), an denen
+Fahrzeuge zwischen Aufträgen warten können.
+
+## Hintergrund
+
+Ein **Parkplatz** ist ein definierter Wartepunkt für Fahrzeuge, an dem
+diese stationieren, ohne den Verkehr zu behindern oder unnötig Strom
+zu verbrauchen. Nach einer Fahrt sucht der Optimierer den nächsten
+geeigneten Parkplatz, falls für eine bestimmte Zeit kein Folgeauftrag
+ansteht.
+
+Jeder Parkplatz besitzt:
+- eine eindeutige Kennung,
+- eine geografische Position,
+- eine maximale Standzeit in Sekunden.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet ist im System hinterlegt.
+- Es sind keine Fahrzeuge aktiv.
+
+## Testfälle
+
+```gherkin
+Funktionalität: Verwaltung von Parkplätzen
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und es sind keine Fahrzeuge aktiv
+
+  Szenario: Einen neuen Parkplatz anlegen
+    Wenn ein Parkplatz mit eindeutiger Kennung,
+         gültiger Position und maximaler Standzeit angelegt wird
+    Dann bestätigt das System die Aufnahme erfolgreich
+
+  Szenario: Anlegen mit unvollständigen Daten ablehnen
+    Wenn ein Parkplatz mit leerer Kennung und ohne Position angelegt
+         werden soll
+    Dann lehnt das System die Anfrage als ungültig ab
+```
+
+## Bemerkungen
+
+- Die Position muss innerhalb eines Betriebsgebiets liegen.
+- Die maximale Standzeit ist eine Empfehlung für den Optimierer; sie
+  stellt sicher, dass Parkplätze nicht dauerhaft blockiert werden.

--- a/reisewitz-test/01-stammdaten/05-planning-configuration.md
+++ b/reisewitz-test/01-stammdaten/05-planning-configuration.md
@@ -1,0 +1,56 @@
+# Testfall: Planungskonfiguration
+
+## Zweck
+
+Prüft das Anlegen und die Validierung der **Planungskonfiguration** —
+der globalen Stellschrauben des Optimierers.
+
+## Hintergrund
+
+Die **Planungskonfiguration** bestimmt, wie der Optimierer
+Fahrtanfragen bearbeitet. Sie umfasst unter anderem:
+
+- **Toleranzen** für Fahrzeit und verbleibende Akkukapazität,
+- **Manöverzeiten** für Ein- und Aussteigen sowie An- und Abkoppeln,
+- **Ladelogik-Schwellen** (ab welchem Akkustand wird zwingend geladen,
+  ab welchem darf das Laden beendet werden),
+- die **Vorschlags-Anzahl** je Anfrage,
+- den **Planungshorizont** in Stunden,
+- den **Planungsmodus** (z. B. mit oder ohne Konvoi),
+- die Schwelle, ab der ein Pro für die Strecke verwendet wird.
+
+Diese Werte gelten systemweit und gelten als gesetzt, solange sie nicht
+explizit überschrieben werden.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet ist im System hinterlegt.
+- Es sind keine Fahrzeuge aktiv.
+
+## Testfälle
+
+```gherkin
+Funktionalität: Anlegen einer Planungskonfiguration
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und es sind keine Fahrzeuge aktiv
+
+  Szenario: Eine vollständige Konfiguration anlegen
+    Wenn eine Planungskonfiguration mit gesetzter Vorschlags-Anzahl,
+         positivem Planungshorizont und sinnvollen Toleranzen
+         angelegt wird
+    Dann bestätigt das System die Aufnahme erfolgreich
+
+  Szenario: Anlegen ohne Pflichtwerte ablehnen
+    Wenn eine Planungskonfiguration ohne Vorschlags-Anzahl
+         und ohne Planungshorizont angelegt werden soll
+    Dann lehnt das System die Anfrage als ungültig ab
+```
+
+## Bemerkungen
+
+- Eine Konfiguration ohne Vorschlags-Anzahl und Planungshorizont liefert
+  praktisch keinen sinnvollen Output (der Optimierer würde keinen
+  Vorschlag zurückgeben). Solche Konfigurationen werden deshalb
+  bereits beim Anlegen abgewiesen.

--- a/reisewitz-test/01-stammdaten/05-planning-configuration.md
+++ b/reisewitz-test/01-stammdaten/05-planning-configuration.md
@@ -11,7 +11,7 @@ Die **Planungskonfiguration** bestimmt, wie der Optimierer
 Fahrtanfragen bearbeitet. Sie umfasst unter anderem:
 
 - **Toleranzen** für Fahrzeit und verbleibende Akkukapazität,
-- **Manöverzeiten** für Ein- und Aussteigen sowie An- und Abkoppeln,
+- **Manöverzeiten** für Ein- und Aussteigen sowie An- und Abkuppeln,
 - **Ladelogik-Schwellen** (ab welchem Akkustand wird zwingend geladen,
   ab welchem darf das Laden beendet werden),
 - die **Vorschlags-Anzahl** je Anfrage,

--- a/reisewitz-test/01-stammdaten/06-vehicletype-setting.md
+++ b/reisewitz-test/01-stammdaten/06-vehicletype-setting.md
@@ -1,0 +1,55 @@
+# Testfall: Fahrzeugtyp-Einstellung
+
+## Zweck
+
+Prüft Anlegen, Auflisten und Validierung der **Fahrzeugtyp-Einstellung**
+(VehicleTypeSetting) — Routing-Profile pro Fahrzeugklasse.
+
+## Hintergrund
+
+Eine **Fahrzeugtyp-Einstellung** ordnet jedem Fahrzeugtyp (z. B.
+„cab-standard", „pro-standard") ein **Routing-Profil** zu. Damit weiß
+der Optimierer, welcher externe Routing-Dienst für einen Cab oder Pro
+zuständig ist (sie können verschiedene Geschwindigkeitsprofile,
+Streckenrestriktionen oder Karten verwenden).
+
+Jeder Eintrag besitzt:
+- einen eindeutigen Schlüssel (Name des Fahrzeugtyps),
+- eine sprechende Bezeichnung,
+- die Adresse des zugehörigen Routing-Dienstes.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet ist im System hinterlegt.
+- Es sind keine Fahrzeuge aktiv.
+
+## Testfälle
+
+```gherkin
+Funktionalität: Verwaltung von Fahrzeugtyp-Einstellungen
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und es sind keine Fahrzeuge aktiv
+
+  Szenario: Eine neue Fahrzeugtyp-Einstellung anlegen
+    Wenn eine Fahrzeugtyp-Einstellung mit eindeutigem Schlüssel
+         und sprechender Bezeichnung angelegt wird
+    Dann bestätigt das System die Aufnahme erfolgreich
+
+  Szenario: Liste aller Fahrzeugtyp-Einstellungen lesen
+    Wenn die Liste aller Fahrzeugtyp-Einstellungen angefragt wird
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält die Liste aller bekannten Einträge
+
+  Szenario: Anlegen ohne Pflichtfelder ablehnen
+    Wenn eine Fahrzeugtyp-Einstellung mit leerem Schlüssel
+         und leerer Bezeichnung angelegt werden soll
+    Dann lehnt das System die Anfrage als ungültig ab
+```
+
+## Bemerkungen
+
+- Der Schlüssel sollte einem Fahrzeugtyp entsprechen, der auch in
+  einem realen Fahrzeug-Datensatz verwendet wird; sonst kann der
+  Optimierer für dieses Fahrzeug keine Routen berechnen.

--- a/reisewitz-test/01-stammdaten/README.md
+++ b/reisewitz-test/01-stammdaten/README.md
@@ -10,7 +10,7 @@ Grundlage für die Fahrtenplanung.
 | Datei | Domänenobjekt | Beschreibung |
 |---|---|---|
 | [Einstiegspunkt](01-accesspoint.md) | AccessPoint | Definierte Ein-/Ausstiegsorte (z. B. Bahnhof) |
-| [Kopplungsort](02-chaininglocation.md) | ChainingLocation | Orte, an denen Cab und Pro gekoppelt werden |
+| [Kopplungsort](02-chaininglocation.md) | ChainingLocation | Orte, an denen Cab und Pro per Kupplung verbunden oder voneinander gelöst werden |
 | [Betriebsgebiet](03-operationarea.md) | OperationArea | Geografisches Polygon der Servicezone |
 | [Parkplatz](04-parkinglocation.md) | ParkingLocation | Wartepunkte für Fahrzeuge |
 | [Planungskonfiguration](05-planning-configuration.md) | PlanningConfiguration | Globale Optimierer-Parameter |

--- a/reisewitz-test/01-stammdaten/README.md
+++ b/reisewitz-test/01-stammdaten/README.md
@@ -1,0 +1,31 @@
+# 01 – Stammdaten
+
+Diese Tests prüfen die grundlegenden CRUD-Operationen (Create, Read,
+Update, Delete) für die statischen Domänenobjekte des Systems. Diese
+Objekte verändern sich im laufenden Betrieb selten und bilden die
+Grundlage für die Fahrtenplanung.
+
+## Geprüfte Objekte
+
+| Datei | Domänenobjekt | Beschreibung |
+|---|---|---|
+| [Einstiegspunkt](01-accesspoint.md) | AccessPoint | Definierte Ein-/Ausstiegsorte (z. B. Bahnhof) |
+| [Kopplungsort](02-chaininglocation.md) | ChainingLocation | Orte, an denen Cab und Pro gekoppelt werden |
+| [Betriebsgebiet](03-operationarea.md) | OperationArea | Geografisches Polygon der Servicezone |
+| [Parkplatz](04-parkinglocation.md) | ParkingLocation | Wartepunkte für Fahrzeuge |
+| [Planungskonfiguration](05-planning-configuration.md) | PlanningConfiguration | Globale Optimierer-Parameter |
+| [Fahrzeugtyp-Einstellung](06-vehicletype-setting.md) | VehicleTypeSetting | Routing-Optionen je Fahrzeugtyp |
+
+## Gemeinsame Struktur der CRUD-Tests
+
+Jeder CRUD-Testfall prüft denselben Lebenszyklus eines Eintrags:
+
+1. **Anlegen** — neuer Eintrag mit gültigen Daten
+2. **Einzeln lesen** — Eintrag über seine ID abrufen
+3. **Liste lesen** — alle Einträge des Objekttyps abrufen
+4. **Löschen** — Eintrag entfernen
+5. **Nach Löschen lesen** — Bestätigung, dass der Eintrag nicht mehr existiert
+6. **Negativ-Anlegen** — Anlegen mit unvollständigen oder ungültigen Daten
+7. **Negativ-Löschen** — Löschen einer nicht existierenden ID
+
+Schritte 1–4 sind der Glücksfall, 5–7 prüfen Fehlerverhalten.

--- a/reisewitz-test/02-fahrzeuge-und-laden/01-cab.md
+++ b/reisewitz-test/02-fahrzeuge-und-laden/01-cab.md
@@ -9,10 +9,12 @@ bei ungültigen oder nicht vorhandenen Daten.
 ## Hintergrund
 
 Ein **Cab** ist das eigentliche Personenfahrzeug, das Fahrgäste von
-ihrem Start zum Ziel bringt. Cabs sind autonom und können:
+ihrem Start zum Ziel bringt. Cabs fahren autonom und werden
+**elektrisch** angetrieben. Sie können:
 - direkt einzeln fahren (Kurzstrecke innerhalb des Betriebsgebiets),
-- auf einem **Pro** mitfahren, um auf Schnellstraßen längere Strecken
-  energieeffizient zurückzulegen.
+- per Kupplung an ein **Pro** angehängt werden, um auf längeren
+  Strecken den eigenen Akku zu schonen — über dieselbe Kupplung wird
+  das Cab während der Fahrt vom Pro nachgeladen.
 
 Jedes Cab besitzt:
 - eine eindeutige Kennung und ein Kennzeichen,

--- a/reisewitz-test/02-fahrzeuge-und-laden/01-cab.md
+++ b/reisewitz-test/02-fahrzeuge-und-laden/01-cab.md
@@ -1,0 +1,85 @@
+# Testfall: Cab-Verwaltung
+
+## Zweck
+
+Prüft den vollständigen Lebenszyklus eines **Cab** — vom Einplanen
+über das Lesen bis zum Außerdienststellen — sowie das Fehlerverhalten
+bei ungültigen oder nicht vorhandenen Daten.
+
+## Hintergrund
+
+Ein **Cab** ist das eigentliche Personenfahrzeug, das Fahrgäste von
+ihrem Start zum Ziel bringt. Cabs sind autonom und können:
+- direkt einzeln fahren (Kurzstrecke innerhalb des Betriebsgebiets),
+- auf einem **Pro** mitfahren, um auf Schnellstraßen längere Strecken
+  energieeffizient zurückzulegen.
+
+Jedes Cab besitzt:
+- eine eindeutige Kennung und ein Kennzeichen,
+- einen Schichtplan (Verfügbarkeitsfenster mit Start- und Endzeit),
+- einen Fahrzeugtyp (verweist auf eine Fahrzeugtyp-Einstellung mit dem
+  passenden Routing-Profil),
+- Energiedaten (Gesamt- und Anfangs-Akkukapazität, Verbrauchsangaben),
+- die Anzahl Sitzplätze,
+- eine maximale autonome Geschwindigkeit,
+- einen Startort.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet, Einstiegspunkte und Fahrzeugtyp-Einstellungen
+  sind im System hinterlegt.
+- Es sind zu Testbeginn keine Fahrzeuge aktiv.
+
+## Testfälle
+
+```gherkin
+Funktionalität: Verwaltung von Cabs
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet und passende Stammdaten sind hinterlegt
+    Und es sind zu Testbeginn keine Fahrzeuge aktiv
+
+  Szenario: Ein neues Cab in den Einsatzplan aufnehmen
+    Wenn ein Cab mit eindeutiger Kennung, Kennzeichen, Fahrzeugtyp,
+         Betreiber, Schichtplan, Startort, Sitzplatzanzahl und
+         vollständigen Energiedaten angelegt wird
+    Dann nimmt das System das Fahrzeug erfolgreich in den Einsatzplan auf
+
+  Szenario: Ein vorhandenes Cab einzeln lesen
+    Angenommen ein Cab mit der Kennung "cab-crud-test" wurde angelegt
+    Wenn dieses Cab über seine Kennung abgefragt wird
+    Dann liefert das System die Fahrzeugdaten erfolgreich zurück
+
+  Szenario: Alle Cabs als Liste lesen
+    Wenn die Liste aller Cabs angefragt wird
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält alle aktiven Cabs
+
+  Szenario: Ein Cab aus dem Einsatzplan entfernen
+    Angenommen ein Cab mit der Kennung "cab-crud-test" existiert
+    Wenn das Cab über seine Kennung gelöscht wird
+    Dann bestätigt das System die Außerdienststellung erfolgreich
+
+  Szenario: Ein gelöschtes Cab erneut lesen
+    Angenommen das Cab "cab-crud-test" wurde soeben gelöscht
+    Wenn dieses Cab erneut abgefragt wird
+    Dann meldet das System, dass das Fahrzeug nicht gefunden wurde
+
+  Szenario: Anlegen mit unvollständigen Daten ablehnen
+    Wenn ein Cab ohne Kennung, ohne Fahrzeugtyp und ohne Betreiber
+         angelegt werden soll
+    Dann lehnt das System die Anfrage als ungültig ab
+
+  Szenario: Löschen einer nicht vorhandenen Kennung ablehnen
+    Wenn ein Cab mit der Kennung "ghost-id" gelöscht werden soll,
+         obwohl kein solches Fahrzeug existiert
+    Dann meldet das System, dass das Fahrzeug nicht gefunden wurde
+```
+
+## Bemerkungen
+
+- Das Anlegen liefert den Status „Erstellt" (HTTP 201) zurück, im
+  Unterschied zum allgemeinen „OK" (HTTP 200) bei reinen Lesezugriffen.
+- Der Schichtplan begrenzt die Verfügbarkeit: Fahrtanfragen außerhalb
+  dieses Fensters führen zu keinem Angebot mit diesem Cab.
+- Die Sitzplatzanzahl beschränkt die Personenzahl je Anfrage.

--- a/reisewitz-test/02-fahrzeuge-und-laden/02-pro.md
+++ b/reisewitz-test/02-fahrzeuge-und-laden/02-pro.md
@@ -1,0 +1,86 @@
+# Testfall: Pro-Verwaltung
+
+## Zweck
+
+Prüft den vollständigen Lebenszyklus eines **Pro** sowie das
+Fehlerverhalten bei ungültigen oder nicht vorhandenen Daten.
+
+## Hintergrund
+
+Ein **Pro** ist ein großes Trägerfahrzeug, das mehrere **Cabs** auf
+längeren Strecken im Konvoi mitnehmen kann. Cabs fahren selbständig
+zum **Kopplungsort**, koppeln dort an den Pro an, lassen sich
+energieeffizient mitschleppen und koppeln am nächsten Kopplungsort
+wieder ab, um die letzten Kilometer wieder selbständig zu fahren.
+
+Jeder Pro besitzt:
+- eine eindeutige Kennung und ein Kennzeichen,
+- einen Schichtplan (Verfügbarkeitsfenster mit Start- und Endzeit),
+- einen Fahrzeugtyp (verweist auf eine Fahrzeugtyp-Einstellung mit dem
+  passenden Routing-Profil),
+- Energiedaten (Gesamt- und Anfangs-Akkukapazität, Verbrauchsangaben),
+- die maximale Anzahl mitnehmbarer Cabs,
+- eine optionale Liste zusätzlicher Energieverbräuche pro mitgenommenem
+  Cab (für genauere Reichweitenrechnung),
+- die maximale Ladeleistung, die der Pro selbst empfangen kann,
+- einen Startort.
+
+## Voraussetzungen
+
+- Ein Konvoi-Stammdatensatz mit Kopplungsorten, Routen und
+  Fahrzeugtyp-Einstellungen ist im System hinterlegt.
+- Es sind zu Testbeginn keine Fahrzeuge aktiv.
+
+## Testfälle
+
+```gherkin
+Funktionalität: Verwaltung von Pros
+
+  Hintergrund:
+    Angenommen ein Konvoi-Stammdatensatz mit Kopplungsorten ist hinterlegt
+    Und es sind zu Testbeginn keine Fahrzeuge aktiv
+
+  Szenario: Einen neuen Pro in den Einsatzplan aufnehmen
+    Wenn ein Pro mit eindeutiger Kennung, Kennzeichen, Fahrzeugtyp,
+         Schichtplan, Startort, maximaler Cab-Anzahl
+         und vollständigen Energiedaten angelegt wird
+    Dann nimmt das System das Fahrzeug erfolgreich in den Einsatzplan auf
+
+  Szenario: Einen vorhandenen Pro einzeln lesen
+    Angenommen ein Pro mit der Kennung "pro-crud-test" wurde angelegt
+    Wenn dieser Pro über seine Kennung abgefragt wird
+    Dann liefert das System die Fahrzeugdaten erfolgreich zurück
+
+  Szenario: Alle Pros als Liste lesen
+    Wenn die Liste aller Pros angefragt wird
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält alle aktiven Pros
+
+  Szenario: Einen Pro aus dem Einsatzplan entfernen
+    Angenommen ein Pro mit der Kennung "pro-crud-test" existiert
+    Wenn der Pro über seine Kennung gelöscht wird
+    Dann bestätigt das System die Außerdienststellung erfolgreich
+
+  Szenario: Einen gelöschten Pro erneut lesen
+    Angenommen der Pro "pro-crud-test" wurde soeben gelöscht
+    Wenn dieser Pro erneut abgefragt wird
+    Dann meldet das System, dass das Fahrzeug nicht gefunden wurde
+
+  Szenario: Anlegen mit unvollständigen Daten ablehnen
+    Wenn ein Pro ohne Kennung, ohne Fahrzeugtyp und ohne Betreiber
+         angelegt werden soll
+    Dann lehnt das System die Anfrage als ungültig ab
+
+  Szenario: Löschen einer nicht vorhandenen Kennung ablehnen
+    Wenn ein Pro mit der Kennung "ghost-id" gelöscht werden soll,
+         obwohl kein solches Fahrzeug existiert
+    Dann meldet das System, dass das Fahrzeug nicht gefunden wurde
+```
+
+## Bemerkungen
+
+- Pros werden nur eingeplant, wenn die Strecke einer Fahrtanfrage einen
+  konfigurierten Schwellwert überschreitet — auf kurzen Strecken fährt
+  das Cab direkt allein.
+- Die maximale Cab-Anzahl pro Pro beeinflusst, wie viele
+  Konvoi-Fahrten parallel gebildet werden können.

--- a/reisewitz-test/02-fahrzeuge-und-laden/02-pro.md
+++ b/reisewitz-test/02-fahrzeuge-und-laden/02-pro.md
@@ -7,22 +7,28 @@ Fehlerverhalten bei ungültigen oder nicht vorhandenen Daten.
 
 ## Hintergrund
 
-Ein **Pro** ist ein großes Trägerfahrzeug, das mehrere **Cabs** auf
-längeren Strecken im Konvoi mitnehmen kann. Cabs fahren selbständig
-zum **Kopplungsort**, koppeln dort an den Pro an, lassen sich
-energieeffizient mitschleppen und koppeln am nächsten Kopplungsort
-wieder ab, um die letzten Kilometer wieder selbständig zu fahren.
+Ein **Pro** ist ein großes, **mit Wasserstoff betriebenes**
+Zugfahrzeug. Auf längeren Strecken werden mehrere **Cabs** per
+Kupplung an das Pro angehängt; das Pro zieht die Cabs als Verbund.
+Über dieselbe Kupplung lädt das Pro die Akkus der angehängten Cabs
+während der Fahrt nach. Cabs fahren selbständig zum
+**Kopplungsort**, werden dort angekuppelt, fahren mit dem Pro bis
+zum Ziel-Kopplungsort, werden dort wieder abgekuppelt und legen
+die letzten Kilometer eigenständig zurück — typischerweise mit
+deutlich höherem Akkustand als zu Beginn der Konvoi-Fahrt.
 
 Jeder Pro besitzt:
 - eine eindeutige Kennung und ein Kennzeichen,
 - einen Schichtplan (Verfügbarkeitsfenster mit Start- und Endzeit),
 - einen Fahrzeugtyp (verweist auf eine Fahrzeugtyp-Einstellung mit dem
   passenden Routing-Profil),
-- Energiedaten (Gesamt- und Anfangs-Akkukapazität, Verbrauchsangaben),
-- die maximale Anzahl mitnehmbarer Cabs,
-- eine optionale Liste zusätzlicher Energieverbräuche pro mitgenommenem
-  Cab (für genauere Reichweitenrechnung),
-- die maximale Ladeleistung, die der Pro selbst empfangen kann,
+- Energiedaten (Gesamt- und Anfangs-Energievorrat des Wasserstofftanks,
+  Verbrauchsangaben),
+- die maximale Anzahl gleichzeitig angekuppelter Cabs,
+- eine optionale Liste zusätzlicher Verbräuche pro angekuppeltem Cab
+  (für genauere Reichweitenrechnung),
+- die maximale Ladeleistung, mit der das Pro die angekuppelten Cabs
+  versorgen kann,
 - einen Startort.
 
 ## Voraussetzungen
@@ -42,8 +48,8 @@ Funktionalität: Verwaltung von Pros
 
   Szenario: Einen neuen Pro in den Einsatzplan aufnehmen
     Wenn ein Pro mit eindeutiger Kennung, Kennzeichen, Fahrzeugtyp,
-         Schichtplan, Startort, maximaler Cab-Anzahl
-         und vollständigen Energiedaten angelegt wird
+         Schichtplan, Startort, maximaler Anzahl gleichzeitig
+         angekuppelter Cabs und vollständigen Energiedaten angelegt wird
     Dann nimmt das System das Fahrzeug erfolgreich in den Einsatzplan auf
 
   Szenario: Einen vorhandenen Pro einzeln lesen
@@ -82,5 +88,9 @@ Funktionalität: Verwaltung von Pros
 - Pros werden nur eingeplant, wenn die Strecke einer Fahrtanfrage einen
   konfigurierten Schwellwert überschreitet — auf kurzen Strecken fährt
   das Cab direkt allein.
-- Die maximale Cab-Anzahl pro Pro beeinflusst, wie viele
-  Konvoi-Fahrten parallel gebildet werden können.
+- Die maximale Anzahl gleichzeitig angekuppelter Cabs pro Pro
+  beeinflusst, wie viele Konvoi-Fahrten parallel gebildet werden
+  können.
+- Die Ladefunktion über die Kupplung ergänzt die stationären
+  Ladepunkte: ein Cab nach einer Konvoi-Fahrt kann oft direkt in den
+  nächsten Auftrag gehen, ohne zusätzlich an eine Ladesäule zu fahren.

--- a/reisewitz-test/02-fahrzeuge-und-laden/03-charging-point.md
+++ b/reisewitz-test/02-fahrzeuge-und-laden/03-charging-point.md
@@ -1,0 +1,76 @@
+# Testfall: Ladepunkt-Verwaltung
+
+## Zweck
+
+Prüft den vollständigen Lebenszyklus eines **Ladepunkts**
+(ChargingPoint).
+
+## Hintergrund
+
+Ein **Ladepunkt** ist eine stationäre Ladesäule, an der Fahrzeuge ihre
+Akkus aufladen. Der Optimierer plant Ladepausen ein, sobald der
+Akkustand eines Fahrzeugs unter einen konfigurierten Schwellwert
+fällt, und reserviert für diese Zeit den Ladepunkt.
+
+Jeder Ladepunkt besitzt:
+- eine eindeutige Kennung,
+- eine geografische Position,
+- eine maximale Standzeit (wie lange ein Fahrzeug dort blockieren darf),
+- eine maximale Ladeleistung (in Watt).
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet ist im System hinterlegt.
+- Es sind keine Fahrzeuge aktiv.
+
+## Testfälle
+
+```gherkin
+Funktionalität: Verwaltung von Ladepunkten
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und es sind keine Fahrzeuge aktiv
+
+  Szenario: Einen neuen Ladepunkt anlegen
+    Wenn ein Ladepunkt mit eindeutiger Kennung, gültiger Position,
+         maximaler Standzeit und maximaler Ladeleistung angelegt wird
+    Dann bestätigt das System die Aufnahme erfolgreich
+
+  Szenario: Einen vorhandenen Ladepunkt einzeln lesen
+    Angenommen ein Ladepunkt mit der Kennung "cp-crud-test" wurde angelegt
+    Wenn dieser Ladepunkt über seine Kennung abgefragt wird
+    Dann liefert das System den Eintrag erfolgreich zurück
+
+  Szenario: Alle Ladepunkte als Liste lesen
+    Wenn die Liste aller Ladepunkte angefragt wird
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält die Liste aller bekannten Ladepunkte
+
+  Szenario: Einen Ladepunkt löschen
+    Angenommen ein Ladepunkt mit der Kennung "cp-crud-test" existiert
+    Wenn der Ladepunkt über seine Kennung gelöscht wird
+    Dann bestätigt das System die Löschung erfolgreich
+
+  Szenario: Einen gelöschten Ladepunkt erneut lesen
+    Angenommen der Ladepunkt "cp-crud-test" wurde soeben gelöscht
+    Wenn dieser Ladepunkt erneut abgefragt wird
+    Dann meldet das System, dass der Eintrag nicht gefunden wurde
+
+  Szenario: Anlegen mit unvollständigen Daten ablehnen
+    Wenn ein Ladepunkt mit leerer Kennung und leerem Bezeichnungsfeld
+         angelegt werden soll
+    Dann lehnt das System die Anfrage als ungültig ab
+
+  Szenario: Löschen einer nicht vorhandenen Kennung ablehnen
+    Wenn ein Ladepunkt mit der Kennung "ghost-id" gelöscht werden soll,
+         obwohl kein solcher Eintrag existiert
+    Dann meldet das System, dass der Eintrag nicht gefunden wurde
+```
+
+## Bemerkungen
+
+- Die maximale Ladeleistung wird in Watt angegeben. Eine Säule mit
+  50.000 Watt entspricht einem Schnellladepunkt mit 50 kW.
+- Die maximale Standzeit verhindert, dass ein Fahrzeug einen Ladepunkt
+  über die geplante Ladedauer hinaus blockiert.

--- a/reisewitz-test/02-fahrzeuge-und-laden/04-charging-point-assignment.md
+++ b/reisewitz-test/02-fahrzeuge-und-laden/04-charging-point-assignment.md
@@ -1,0 +1,82 @@
+# Testfall: Ladebelegung-Verwaltung
+
+## Zweck
+
+Prüft den vollständigen Lebenszyklus einer **Ladebelegung**
+(ChargingPointAssignment) — der Reservierung eines Ladepunkts durch
+ein bestimmtes Fahrzeug für ein bestimmtes Zeitfenster.
+
+## Hintergrund
+
+Wenn der Optimierer plant, ein Fahrzeug zwischen zwei Aufträgen aufladen
+zu lassen, legt er eine **Ladebelegung** an. Diese reserviert einen
+**Ladepunkt** für das Fahrzeug von einer Startzeit bis zu einer Endzeit.
+Während der Belegung wird der Ladepunkt für andere Fahrzeuge gesperrt.
+
+Jede Ladebelegung verknüpft:
+- den Ladepunkt (über dessen Kennung),
+- das Fahrzeug (über dessen Kennung),
+- den Beginn der Belegung,
+- das Ende der Belegung.
+
+Beim Anlegen vergibt das System eine eigene, eindeutige Belegungs-ID,
+über die sich die Belegung später lesen oder löschen lässt.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet ist im System hinterlegt.
+- Mindestens ein Cab und ein Ladepunkt sind aktiv.
+
+## Testfälle
+
+```gherkin
+Funktionalität: Verwaltung von Ladebelegungen
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und mindestens ein Cab und ein Ladepunkt sind aktiv
+
+  Szenario: Eine neue Ladebelegung anlegen
+    Wenn eine Ladebelegung mit gültigem Ladepunkt, gültigem Fahrzeug
+         und einem Zeitfenster (Beginn vor Ende) angelegt wird
+    Dann bestätigt das System die Aufnahme erfolgreich
+    Und liefert eine eindeutige Belegungs-ID zurück
+
+  Szenario: Eine vorhandene Ladebelegung einzeln lesen
+    Angenommen eine Ladebelegung mit einer bekannten Belegungs-ID existiert
+    Wenn diese Ladebelegung über ihre Belegungs-ID abgefragt wird
+    Dann liefert das System den Eintrag erfolgreich zurück
+
+  Szenario: Alle Ladebelegungen als Liste lesen
+    Wenn die Liste aller Ladebelegungen angefragt wird
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält die Liste aller bekannten Belegungen
+
+  Szenario: Eine Ladebelegung löschen
+    Angenommen eine Ladebelegung mit einer bekannten Belegungs-ID existiert
+    Wenn die Ladebelegung über ihre Belegungs-ID gelöscht wird
+    Dann bestätigt das System die Löschung erfolgreich
+
+  Szenario: Eine gelöschte Ladebelegung erneut lesen
+    Angenommen eine Ladebelegung wurde soeben gelöscht
+    Wenn diese Ladebelegung erneut abgefragt wird
+    Dann meldet das System, dass der Eintrag nicht gefunden wurde
+
+  Szenario: Anlegen mit unvollständigen Daten ablehnen
+    Wenn eine Ladebelegung ohne Ladepunkt-Kennung
+         und ohne Fahrzeug-Kennung angelegt werden soll
+    Dann lehnt das System die Anfrage als ungültig ab
+
+  Szenario: Löschen einer nicht vorhandenen Belegungs-ID ablehnen
+    Wenn eine Ladebelegung mit der Belegungs-ID "ghost-id" gelöscht werden
+         soll, obwohl keine solche Belegung existiert
+    Dann meldet das System, dass die Belegung nicht gefunden wurde
+```
+
+## Bemerkungen
+
+- Eine Ladebelegung verbindet immer genau einen Ladepunkt mit genau
+  einem Fahrzeug. Mehrere parallele Belegungen am selben Ladepunkt
+  sind durch die Zeitfenster getrennt.
+- Die Belegungs-ID ist eine vom System vergebene UUID, nicht die
+  Kennung des Ladepunkts oder des Fahrzeugs.

--- a/reisewitz-test/02-fahrzeuge-und-laden/README.md
+++ b/reisewitz-test/02-fahrzeuge-und-laden/README.md
@@ -7,20 +7,26 @@ Ladeinfrastruktur.
 
 | Datei | Domänenobjekt | Beschreibung |
 |---|---|---|
-| [Cab](01-cab.md) | Cab | Personenfahrzeug (kleine Einheit für Fahrgäste) |
-| [Pro](02-pro.md) | Pro | Trägerfahrzeug, das mehrere Cabs in Konvoi mitnehmen kann |
+| [Cab](01-cab.md) | Cab | Elektrisches Personenfahrzeug (kleine Einheit für Fahrgäste) |
+| [Pro](02-pro.md) | Pro | Wasserstoff-Zugfahrzeug, an das mehrere Cabs per Kupplung angehängt und über die Kupplung geladen werden |
 | [Ladepunkt](03-charging-point.md) | ChargingPoint | Stationäre Ladesäule |
 | [Ladebelegung](04-charging-point-assignment.md) | ChargingPointAssignment | Reservierung eines Ladepunkts durch ein Fahrzeug |
 
 ## Hinweis zur Fahrzeug-Hierarchie
 
-Das System kennt zwei Fahrzeugklassen:
+Das System kennt zwei Fahrzeugklassen mit unterschiedlichen
+Antriebsarten:
 
-- **Cab**: Kleines Personenfahrzeug. Fährt einzeln oder gekoppelt mit
-  einem Pro.
-- **Pro**: Großes Trägerfahrzeug. Nimmt mehrere Cabs auf längeren
-  Strecken im Konvoi mit.
+- **Cab**: Kleines, **elektrisch** betriebenes Personenfahrzeug.
+  Fährt einzeln (kurze Strecken) oder per Kupplung an ein Pro
+  angehängt.
+- **Pro**: Großes **Wasserstoff-betriebenes Zugfahrzeug**. Zieht auf
+  längeren Strecken mehrere angekuppelte Cabs. Über die Kupplung
+  wird zusätzlich der Cab-Akku während der Fahrt geladen, sodass
+  Cabs nach dem Abkuppeln mit erhöhter Restreichweite weiterfahren.
 
-Beide haben eigene Lebenszyklen, eigene Schichtpläne und eigene
-Ladevorgänge, weshalb sie in getrennten Schnittstellen verwaltet
-werden.
+Beide Klassen haben eigene Lebenszyklen, eigene Schichtpläne und
+eigene Ladevorgänge, weshalb sie in getrennten Schnittstellen
+verwaltet werden. **Stationäre Ladepunkte** (siehe Ladepunkt- und
+Ladebelegung-Tests) ergänzen das Laden über die Kupplung um die
+Möglichkeit, Cabs zwischen Aufträgen am Strom zu laden.

--- a/reisewitz-test/02-fahrzeuge-und-laden/README.md
+++ b/reisewitz-test/02-fahrzeuge-und-laden/README.md
@@ -1,0 +1,26 @@
+# 02 – Fahrzeuge und Laden
+
+Tests rund um die Fahrzeugflotte (Cabs und Pros) und die zugehörige
+Ladeinfrastruktur.
+
+## Geprüfte Objekte
+
+| Datei | Domänenobjekt | Beschreibung |
+|---|---|---|
+| [Cab](01-cab.md) | Cab | Personenfahrzeug (kleine Einheit für Fahrgäste) |
+| [Pro](02-pro.md) | Pro | Trägerfahrzeug, das mehrere Cabs in Konvoi mitnehmen kann |
+| [Ladepunkt](03-charging-point.md) | ChargingPoint | Stationäre Ladesäule |
+| [Ladebelegung](04-charging-point-assignment.md) | ChargingPointAssignment | Reservierung eines Ladepunkts durch ein Fahrzeug |
+
+## Hinweis zur Fahrzeug-Hierarchie
+
+Das System kennt zwei Fahrzeugklassen:
+
+- **Cab**: Kleines Personenfahrzeug. Fährt einzeln oder gekoppelt mit
+  einem Pro.
+- **Pro**: Großes Trägerfahrzeug. Nimmt mehrere Cabs auf längeren
+  Strecken im Konvoi mit.
+
+Beide haben eigene Lebenszyklen, eigene Schichtpläne und eigene
+Ladevorgänge, weshalb sie in getrennten Schnittstellen verwaltet
+werden.

--- a/reisewitz-test/03-fahrtanfragen/01-trip-direkt-1-cab.md
+++ b/reisewitz-test/03-fahrtanfragen/01-trip-direkt-1-cab.md
@@ -1,0 +1,52 @@
+# Testfall: Fahrtanfrage mit einem Cab
+
+## Zweck
+
+Verifiziert den **Glücksfall**: Ein Fahrgast stellt eine Fahrtanfrage
+für eine kurze Strecke innerhalb des Betriebsgebiets, und das System
+liefert mindestens einen konkreten Fahrvorschlag.
+
+## Hintergrund
+
+Dies ist der einfachste Trip-Fall: Eine Strecke, die ein einzelnes
+**Cab** allein bedienen kann (kein Konvoi nötig). Start und Ziel
+liegen beide im Betriebsgebiet, der Wunsch-Pickup-Zeitpunkt fällt in
+das Verfügbarkeitsfenster des Fahrzeugs, und die Fahrtdauer
+unterschreitet die Schwelle, ab der ein Pro-Trägerfahrzeug
+hinzugezogen würde.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet rund um Paderborn ist hinterlegt.
+- Ein einsatzbereites Cab ist eingeplant, dessen Schichtplan den
+  Wunsch-Pickup-Zeitpunkt einschließt.
+- Die Pickup-Position (Bahnhof) und die Ziel-Position (Universität)
+  liegen beide im Betriebsgebiet.
+
+## Testfall
+
+```gherkin
+Funktionalität: Fahrtanfrage mit einem verfügbaren Cab
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und genau ein Cab ist während des angefragten Zeitfensters einsatzbereit
+
+  Szenario: Anfrage liefert mindestens ein Angebot
+    Wenn ein Fahrgast eine Fahrt vom Bahnhof zur Universität
+         für ein Zeitfenster innerhalb der Cab-Schicht anfragt
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält mindestens einen Fahrvorschlag
+    Und der Vorschlag nennt das verfügbare Cab als zugewiesenes Fahrzeug
+```
+
+## Bemerkungen
+
+- „Mindestens einen Vorschlag" bedeutet: der Optimierer hat eine
+  fahrbare Tour mit dem vorhandenen Cab gefunden. Es können mehrere
+  Vorschläge geliefert werden (verschiedene Pickup-Zeiten innerhalb des
+  Wunsch-Fensters), die Anzahl ist über die Planungskonfiguration
+  steuerbar.
+- Liegen die Vorschläge zeitlich vor, blockt das System den Zeitslot
+  des Cabs reservierend, bis die Buchung erfolgt oder das Angebot
+  abläuft.

--- a/reisewitz-test/03-fahrtanfragen/01-trip-direkt-1-cab.md
+++ b/reisewitz-test/03-fahrtanfragen/01-trip-direkt-1-cab.md
@@ -12,7 +12,7 @@ Dies ist der einfachste Trip-Fall: Eine Strecke, die ein einzelnes
 **Cab** allein bedienen kann (kein Konvoi nötig). Start und Ziel
 liegen beide im Betriebsgebiet, der Wunsch-Pickup-Zeitpunkt fällt in
 das Verfügbarkeitsfenster des Fahrzeugs, und die Fahrtdauer
-unterschreitet die Schwelle, ab der ein Pro-Trägerfahrzeug
+unterschreitet die Schwelle, ab der ein Pro als Zugfahrzeug
 hinzugezogen würde.
 
 ## Voraussetzungen

--- a/reisewitz-test/03-fahrtanfragen/02-trip-direkt-2-cabs.md
+++ b/reisewitz-test/03-fahrtanfragen/02-trip-direkt-2-cabs.md
@@ -1,0 +1,45 @@
+# Testfall: Fahrtanfrage bei zwei verfügbaren Cabs
+
+## Zweck
+
+Prüft, dass das System bei mehreren passenden Fahrzeugen einen
+geeigneten Vorschlag liefert.
+
+## Hintergrund
+
+Sind mehrere **Cabs** für eine Anfrage geeignet (passender Schichtplan,
+ausreichend Akku, in der Nähe), trifft der Optimierer eine Auswahl —
+typischerweise das nächstgelegene oder das mit der besten Auslastung.
+Dieser Test stellt sicher, dass das Vorhandensein zusätzlicher Optionen
+weder zu Doppelzuweisungen noch zu null Vorschlägen führt.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet rund um Paderborn ist hinterlegt.
+- Zwei einsatzbereite Cabs sind eingeplant, beide mit Schichtplan
+  über das gesamte Anfragefenster.
+- Beide Cabs starten an unterschiedlichen Punkten im Betriebsgebiet.
+
+## Testfall
+
+```gherkin
+Funktionalität: Fahrtanfrage bei mehreren verfügbaren Cabs
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und zwei Cabs sind während des angefragten Zeitfensters einsatzbereit
+
+  Szenario: Anfrage liefert mindestens ein Angebot
+    Wenn ein Fahrgast eine Fahrt vom Bahnhof zur Universität anfragt
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält mindestens einen Fahrvorschlag
+```
+
+## Bemerkungen
+
+- Der Fahrgast muss sich nicht um die Auswahl kümmern — das System
+  schlägt die geeignetste Variante vor. Werden mehrere Angebote
+  zurückgegeben, kann der Fahrgast wählen.
+- Auch wenn beide Cabs theoretisch fahren könnten, reserviert der
+  Optimierer nur den Zeitslot eines Cabs je Vorschlag, um andere
+  Anfragen nicht unnötig zu blockieren.

--- a/reisewitz-test/03-fahrtanfragen/03-trip-konvoi.md
+++ b/reisewitz-test/03-fahrtanfragen/03-trip-konvoi.md
@@ -3,20 +3,21 @@
 ## Zweck
 
 Verifiziert die Konvoi-Logik des Systems: Bei längeren Strecken
-sollen Cabs nicht alleine fahren, sondern an einem Kopplungsort auf
-einen Pro auffahren, mitfahren und am nächsten Kopplungsort wieder
-abkoppeln.
+sollen Cabs nicht alleine fahren, sondern an einem Kopplungsort per
+Kupplung an ein Pro angehängt werden, mit dem Pro fahren und am
+nächsten Kopplungsort wieder abgekuppelt werden.
 
 ## Hintergrund
 
 Das System unterscheidet zwei Fahrmodi:
 
-- **Direktfahrt**: Das Cab fährt die gesamte Strecke selbst. Sinnvoll
-  bei kurzen Distanzen.
-- **Konvoi**: Das Cab fährt zum nächsten Kopplungsort, koppelt an einen
-  Pro an, lässt sich auf der Hauptstrecke energiesparend mitschleppen,
-  koppelt am Ziel-Kopplungsort wieder ab und fährt die letzten Meter
-  selbständig.
+- **Direktfahrt**: Das elektrische Cab fährt die gesamte Strecke
+  selbst. Sinnvoll bei kurzen Distanzen.
+- **Konvoi**: Das Cab fährt zum nächsten Kopplungsort, wird dort per
+  Kupplung an ein wasserstoffbetriebenes Pro angehängt, fährt
+  zusammen mit dem Pro über die Hauptstrecke (und wird dabei über
+  die Kupplung gleichzeitig nachgeladen), wird am Ziel-Kopplungsort
+  wieder abgekuppelt und fährt die letzten Meter selbständig.
 
 Der Konvoi-Modus wird ab einer in der Planungskonfiguration
 einstellbaren Streckenschwelle eingesetzt. Dieser Test zielt auf eine
@@ -52,7 +53,10 @@ Funktionalität: Fahrtanfrage mit Konvoi-Beförderung
 
 - Der Konvoi-Abschnitt wird intern im Vorschlag hinterlegt; der Fahrgast
   erhält die geplante Gesamtdauer als Information, nicht zwingend die
-  Details des Kopplungsmanövers.
+  Details des Kupplungsmanövers.
 - Auf Strecken unterhalb der Schwelle wählt der Optimierer auch bei
-  vorhandenem Pro die Direktfahrt, weil das An- und Abkoppeln Zeit
-  kostet und sich nur ab einer gewissen Mitfahrdistanz lohnt.
+  vorhandenem Pro die Direktfahrt, weil das An- und Abkuppeln Zeit
+  kostet und sich nur ab einer gewissen gemeinsamen Strecke lohnt.
+- Ein Nebeneffekt der Konvoi-Fahrt: Das Cab erreicht das Ziel mit
+  höherem Akkustand als zu Beginn, weil über die Kupplung während
+  der Fahrt geladen wird.

--- a/reisewitz-test/03-fahrtanfragen/03-trip-konvoi.md
+++ b/reisewitz-test/03-fahrtanfragen/03-trip-konvoi.md
@@ -1,0 +1,58 @@
+# Testfall: Fahrtanfrage mit Konvoi
+
+## Zweck
+
+Verifiziert die Konvoi-Logik des Systems: Bei längeren Strecken
+sollen Cabs nicht alleine fahren, sondern an einem Kopplungsort auf
+einen Pro auffahren, mitfahren und am nächsten Kopplungsort wieder
+abkoppeln.
+
+## Hintergrund
+
+Das System unterscheidet zwei Fahrmodi:
+
+- **Direktfahrt**: Das Cab fährt die gesamte Strecke selbst. Sinnvoll
+  bei kurzen Distanzen.
+- **Konvoi**: Das Cab fährt zum nächsten Kopplungsort, koppelt an einen
+  Pro an, lässt sich auf der Hauptstrecke energiesparend mitschleppen,
+  koppelt am Ziel-Kopplungsort wieder ab und fährt die letzten Meter
+  selbständig.
+
+Der Konvoi-Modus wird ab einer in der Planungskonfiguration
+einstellbaren Streckenschwelle eingesetzt. Dieser Test zielt auf eine
+Strecke, die diese Schwelle überschreitet, sodass der Optimierer ein
+Angebot mit einem Konvoi-Abschnitt generieren muss.
+
+## Voraussetzungen
+
+- Ein Konvoi-fähiger Stammdatensatz ist hinterlegt: Betriebsgebiet,
+  Kopplungsorte, vordefinierte Konvoi-Routen.
+- Mindestens ein Cab und ein Pro sind während des angefragten
+  Zeitfensters einsatzbereit.
+- Die angefragte Strecke (Bahnhof → Schloß Neuhaus) übersteigt die
+  Schwelle, ab der das System einen Konvoi vorzieht.
+
+## Testfall
+
+```gherkin
+Funktionalität: Fahrtanfrage mit Konvoi-Beförderung
+
+  Hintergrund:
+    Angenommen ein Konvoi-Stammdatensatz mit Kopplungsorten ist hinterlegt
+    Und mindestens ein Cab und ein Pro sind einsatzbereit
+    Und die Strecke des Fahrgasts überschreitet die Konvoi-Schwelle
+
+  Szenario: Anfrage liefert ein Angebot mit Konvoi-Abschnitt
+    Wenn ein Fahrgast eine Fahrt vom Bahnhof nach Schloß Neuhaus anfragt
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält mindestens einen Fahrvorschlag
+```
+
+## Bemerkungen
+
+- Der Konvoi-Abschnitt wird intern im Vorschlag hinterlegt; der Fahrgast
+  erhält die geplante Gesamtdauer als Information, nicht zwingend die
+  Details des Kopplungsmanövers.
+- Auf Strecken unterhalb der Schwelle wählt der Optimierer auch bei
+  vorhandenem Pro die Direktfahrt, weil das An- und Abkoppeln Zeit
+  kostet und sich nur ab einer gewissen Mitfahrdistanz lohnt.

--- a/reisewitz-test/03-fahrtanfragen/04-trip-mit-buchung.md
+++ b/reisewitz-test/03-fahrtanfragen/04-trip-mit-buchung.md
@@ -1,0 +1,63 @@
+# Testfall: Vollständiger Buchungsfluss
+
+## Zweck
+
+Prüft den **End-to-End-Fluss** aus Sicht eines Fahrgasts:
+1. Fahrtanfrage stellen,
+2. einen der Vorschläge auswählen und buchen,
+3. den aktuellen Status der gebuchten Fahrt abfragen.
+
+## Hintergrund
+
+Der Buchungsfluss umfasst drei Schritte:
+
+1. **Anfrage** (Trip-Request): Fahrgast schickt Start, Ziel,
+   Wunschzeitfenster. Das System antwortet mit einer **Booking-Transaktion**
+   und einer Liste **Vorschläge** (Proposals), aus denen der Fahrgast
+   wählen kann.
+2. **Buchung** (Trip-Booking): Fahrgast wählt einen Vorschlag aus seiner
+   Anfrage und sendet dessen Schlüssel zurück. Das System verbindlich
+   reserviert das Fahrzeug, vergibt eine **Trip-ID** und leitet die Fahrt
+   ein.
+3. **Status** (Trip-Status): Fahrgast kann jederzeit anhand der Trip-ID
+   den aktuellen Stand abfragen (z. B. „gebucht", „Cab unterwegs",
+   „Cab am Pickup-Ort", „Fahrgast eingestiegen", „abgeschlossen").
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet rund um Paderborn ist hinterlegt.
+- Ein Cab ist während des Anfragefensters einsatzbereit.
+
+## Testfall
+
+```gherkin
+Funktionalität: Anfrage, Buchung und Statusabfrage einer Fahrt
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und ein Cab ist während des angefragten Zeitfensters einsatzbereit
+
+  Szenario: Vollständiger Fluss von Anfrage bis Statusabfrage
+    Wenn ein Fahrgast eine Fahrt vom Bahnhof zur Universität anfragt
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält eine Booking-Transaktion und mindestens einen Vorschlag
+
+    Wenn der Fahrgast den ersten Vorschlag bucht
+    Dann bestätigt das System die Buchung erfolgreich
+    Und liefert eine eindeutige Trip-ID zurück
+
+    Wenn der Fahrgast den Status der Fahrt anhand der Trip-ID abfragt
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält den aktuellen Status der Fahrt
+```
+
+## Bemerkungen
+
+- Die **Booking-Transaktion** identifiziert die Anfrage. Sie ist nötig,
+  damit das System den gewählten Vorschlag der ursprünglichen Anfrage
+  zuordnen kann.
+- Die **Trip-ID** entsteht erst mit der Buchung und ist die Kennung
+  der konkreten, verbindlichen Fahrt.
+- Vorschläge haben eine begrenzte Gültigkeit. Bucht der Fahrgast nicht
+  innerhalb dieser Frist, verfällt das Angebot und der Zeitslot des
+  Cabs wird wieder freigegeben.

--- a/reisewitz-test/03-fahrtanfragen/05-trip-keine-cabs.md
+++ b/reisewitz-test/03-fahrtanfragen/05-trip-keine-cabs.md
@@ -1,0 +1,49 @@
+# Testfall: Fahrtanfrage ohne verfügbare Cabs
+
+## Zweck
+
+Prüft das Verhalten bei einer Anfrage in ein Betriebsgebiet, in dem
+**keine Fahrzeuge** aktiv sind. Erwartet wird kein technischer Fehler,
+sondern eine **erfolgreiche Antwort mit leerer Vorschlagsliste**.
+
+## Hintergrund
+
+Die Abwesenheit verfügbarer Fahrzeuge ist kein Anwendungsfehler — sie
+ist eine zulässige Lage (z. B. nachts, am Wochenende, oder wenn alle
+Cabs gerade in anderen Aufträgen unterwegs sind). Der Fahrgast erhält
+ein gültiges Antwortobjekt mit
+- erfolgreicher Statusmeldung,
+- aber **null Vorschlägen**,
+- und einem entsprechenden Status-Hinweis (z. B. „NoValidCabs").
+
+So kann die Client-Anwendung dem Fahrgast einen sauberen Hinweis
+anzeigen („Aktuell keine Fahrzeuge verfügbar"), statt einen Fehler.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet rund um Paderborn ist hinterlegt.
+- Es sind **keine** Fahrzeuge aktiv (leere Flotte).
+
+## Testfall
+
+```gherkin
+Funktionalität: Fahrtanfrage in leere Flotte
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und es sind keine Fahrzeuge aktiv
+
+  Szenario: Anfrage liefert null Angebote ohne Fehler
+    Wenn ein Fahrgast eine Fahrt vom Bahnhof zur Universität anfragt
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält null Fahrvorschläge
+```
+
+## Bemerkungen
+
+- Dieser Fall unterscheidet sich grundlegend von einem **technischen
+  Fehler** (z. B. Datenbank nicht erreichbar): Die Antwort ist
+  semantisch erfolgreich, sie sagt nur aus, dass es kein Angebot gibt.
+- Auch eine vorhandene Flotte mit Schichtplänen, die das Anfragefenster
+  nicht abdecken, führt zur selben Antwort. Siehe dazu auch den
+  Testfall „Fahrtanfrage außerhalb Verfügbarkeitsfenster".

--- a/reisewitz-test/03-fahrtanfragen/06-trip-zeitkonflikt.md
+++ b/reisewitz-test/03-fahrtanfragen/06-trip-zeitkonflikt.md
@@ -1,0 +1,51 @@
+# Testfall: Fahrtanfrage außerhalb Verfügbarkeitsfenster
+
+## Zweck
+
+Prüft das Verhalten, wenn der gewünschte Pickup-Zeitpunkt **außerhalb
+des Schichtplans** aller aktiven Cabs liegt. Erwartet wird eine
+erfolgreiche Antwort mit leerer Vorschlagsliste.
+
+## Hintergrund
+
+Jedes **Cab** hat einen Schichtplan (Verfügbarkeitsfenster mit Start-
+und Endzeit). Liegt der Wunsch-Pickup eines Fahrgasts außerhalb aller
+Schichtpläne (z. B. nachts um 03:00 Uhr, wenn die Cabs erst ab 06:00
+Uhr fahren), gibt es kein passendes Fahrzeug — auch wenn die Flotte
+selbst nicht leer ist.
+
+Wie bei einer leeren Flotte ist das **kein Fehler**, sondern ein
+gültiger fachlicher Zustand: das System antwortet erfolgreich mit
+null Vorschlägen.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet rund um Paderborn ist hinterlegt.
+- Mindestens ein Cab mit definiertem Schichtplan (z. B. 06:00–23:00
+  Uhr) ist eingeplant.
+- Der angefragte Pickup-Zeitpunkt liegt **außerhalb** dieses
+  Schichtplans (z. B. um 03:00 Uhr).
+
+## Testfall
+
+```gherkin
+Funktionalität: Fahrtanfrage außerhalb Cab-Schichtplan
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und ein Cab ist im Tagesfenster 06:00 bis 23:00 Uhr einsatzbereit
+
+  Szenario: Pickup um 03:00 liefert null Angebote
+    Wenn ein Fahrgast eine Fahrt mit Wunschzeit Pickup um 03:00 Uhr anfragt
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält null Fahrvorschläge
+```
+
+## Bemerkungen
+
+- Aus Sicht des Fahrgasts ist dieses Ergebnis identisch mit dem Fall
+  „keine Cabs aktiv": null Vorschläge. Im Antwortobjekt sind die
+  beiden Fälle aber über den Status unterscheidbar.
+- Der Optimierer prüft die Verfügbarkeit auch innerhalb eines
+  Schichtplans noch genauer (Akku, andere Aufträge); selbst bei
+  passendem Schichtplan kann ein einzelnes Cab abgelehnt werden.

--- a/reisewitz-test/03-fahrtanfragen/07-trip-ausserhalb-betriebsgebiet.md
+++ b/reisewitz-test/03-fahrtanfragen/07-trip-ausserhalb-betriebsgebiet.md
@@ -1,0 +1,52 @@
+# Testfall: Fahrtanfrage außerhalb Betriebsgebiet
+
+## Zweck
+
+Prüft das Verhalten, wenn der **Pickup-Ort** außerhalb des
+**Betriebsgebiets** (OperationArea) liegt. Erwartet wird eine
+erfolgreiche Antwort mit leerer Vorschlagsliste und einem
+entsprechenden Status-Hinweis.
+
+## Hintergrund
+
+Das **Betriebsgebiet** definiert per Polygon, in welcher Region das
+System überhaupt Fahrten anbietet. Liegt entweder der Pickup- oder der
+Ziel-Ort außerhalb dieses Polygons, kann das System die Fahrt nicht
+bedienen.
+
+Das ist **kein Eingabe-Fehler** im technischen Sinn — die Anfrage ist
+strukturell korrekt. Sie ist nur fachlich nicht erfüllbar. Das System
+quittiert deshalb mit einer erfolgreichen Antwort und einem Status-Code,
+der den Grund angibt (z. B. „StartOutsideServiceArea"), aber ohne
+Vorschläge.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet rund um Paderborn ist hinterlegt.
+- Mindestens ein Cab ist einsatzbereit.
+- Der **Pickup-Ort** liegt **außerhalb** des hinterlegten Polygons,
+  der Ziel-Ort innerhalb.
+
+## Testfall
+
+```gherkin
+Funktionalität: Fahrtanfrage mit Pickup außerhalb Betriebsgebiet
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und ein Cab ist einsatzbereit
+
+  Szenario: Pickup-Koordinate außerhalb Polygon liefert null Angebote
+    Wenn ein Fahrgast eine Fahrt anfragt, deren Pickup-Position außerhalb
+         des Betriebsgebiets liegt, das Ziel jedoch innerhalb
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält null Fahrvorschläge
+```
+
+## Bemerkungen
+
+- Dieselbe Antwort entsteht, wenn umgekehrt das **Ziel** außerhalb des
+  Betriebsgebiets liegt — der Status-Code im Antwortobjekt gibt
+  Aufschluss, ob Start oder Ziel betroffen ist.
+- Eine Anfrage komplett außerhalb des Betriebsgebiets (Pickup und Ziel
+  beide außerhalb) wird ebenfalls mit null Vorschlägen quittiert.

--- a/reisewitz-test/03-fahrtanfragen/08-trip-ungueltige-koordinaten.md
+++ b/reisewitz-test/03-fahrtanfragen/08-trip-ungueltige-koordinaten.md
@@ -1,0 +1,57 @@
+# Testfall: Fahrtanfrage mit ungültigen Koordinaten
+
+## Zweck
+
+Prüft das Verhalten bei einer Anfrage mit **fachlich unsinnigen
+Koordinaten** (z. B. Breitengrad 999, Längengrad −999). Solche Werte
+liegen weit außerhalb jeder realen Landfläche und damit auch außerhalb
+jedes Betriebsgebiets.
+
+## Hintergrund
+
+Der Wertebereich für Geokoordinaten ist begrenzt:
+- **Breitengrad** (Latitude): −90 bis +90,
+- **Längengrad** (Longitude): −180 bis +180.
+
+Werte außerhalb dieser Grenzen können nie auf einem Punkt der Erde
+liegen. Trotzdem akzeptiert die Schnittstelle solche Werte derzeit
+strukturell, statt sie schon beim Empfang abzulehnen — sie reicht die
+Anfrage in den fachlichen Pfad weiter, wo sie wie eine ganz normale
+Anfrage außerhalb des Betriebsgebiets behandelt wird.
+
+Das Ergebnis ist deshalb dasselbe wie im Testfall „Fahrtanfrage
+außerhalb Betriebsgebiet": eine erfolgreiche Antwort mit null
+Vorschlägen.
+
+## Voraussetzungen
+
+- Ein Betriebsgebiet rund um Paderborn ist hinterlegt.
+- Mindestens ein Cab ist einsatzbereit.
+
+## Testfall
+
+```gherkin
+Funktionalität: Fahrtanfrage mit unmöglichen Koordinaten
+
+  Hintergrund:
+    Angenommen ein Betriebsgebiet ist im System hinterlegt
+    Und ein Cab ist einsatzbereit
+
+  Szenario: Pickup mit Breitengrad 999 liefert null Angebote
+    Wenn ein Fahrgast eine Fahrt anfragt, deren Pickup-Position
+         außerhalb des gültigen Wertebereichs für Geokoordinaten liegt
+         (Breitengrad 999, Längengrad −999)
+    Dann liefert das System eine erfolgreiche Antwort
+    Und die Antwort enthält null Fahrvorschläge
+```
+
+## Bemerkungen
+
+- Aus Sicht der Anwendung deckt sich dieser Fall mit „Anfrage außerhalb
+  Betriebsgebiet". Der Test ist trotzdem nützlich, um zu verifizieren,
+  dass derart krasse Eingaben das System nicht in einen Fehlerzustand
+  bringen (kein Crash, keine fünfhunderter Statusmeldung).
+- Eine strengere Eingangs-Validierung mit explizitem Wertebereich-Check
+  bleibt eine offene Verbesserungsmöglichkeit; sie würde den Pfad
+  abkürzen und für den Fahrgast zu einer expliziten Fehlermeldung
+  („Bitte gültige Koordinaten angeben") führen.

--- a/reisewitz-test/03-fahrtanfragen/README.md
+++ b/reisewitz-test/03-fahrtanfragen/README.md
@@ -1,0 +1,65 @@
+# 03 – Fahrtanfragen
+
+End-to-End-Tests für den Buchungsfluss: Ein Fahrgast sendet eine
+**Fahrtanfrage** (TripRequest), das System schlägt einen oder mehrere
+**Fahrvorschläge** (Proposals) vor, der Fahrgast wählt einen aus und
+**bucht** ihn (Trip).
+
+Die Tests decken sowohl den Glücksfall (gültige Anfrage führt zu mind.
+einem Angebot) als auch verschiedene Fehlerklassen ab.
+
+## Übersicht der Testfälle
+
+### Positivfälle
+
+| Datei | Szenario |
+|---|---|
+| [Direkt mit einem Cab](01-trip-direkt-1-cab.md) | Eine kurze Fahrt, die ein einzelnes Cab allein fahren kann |
+| [Direkt mit zwei Cabs verfügbar](02-trip-direkt-2-cabs.md) | Wie oben, aber mit zwei Cabs in der Flotte — der Optimierer wählt eines aus |
+| [Konvoi-Szenario](03-trip-konvoi.md) | Lange Strecke, bei der ein Cab vom Pro mitgenommen wird |
+| [Buchung und Status](04-trip-mit-buchung.md) | Vollständiger Fluss: Anfrage → Angebot → Buchung → Status |
+
+### Negativfälle
+
+| Datei | Szenario |
+|---|---|
+| [Keine Cabs verfügbar](05-trip-keine-cabs.md) | Anfrage in ein Betriebsgebiet ohne aktive Fahrzeuge |
+| [Außerhalb Verfügbarkeitsfenster](06-trip-zeitkonflikt.md) | Pickup-Zeit liegt außerhalb der Cab-Schichtpläne |
+| [Außerhalb Betriebsgebiet](07-trip-ausserhalb-betriebsgebiet.md) | Start- oder Zielkoordinate liegt außerhalb des Service-Polygons |
+| [Ungültige Koordinaten](08-trip-ungueltige-koordinaten.md) | Anfrage mit nicht existenten geografischen Werten |
+
+## Datenmodell der Antwort
+
+Auf jede Fahrtanfrage liefert das System eine **TripRequestResponse**.
+Wichtige Felder:
+
+| Feld | Bedeutung |
+|---|---|
+| `bookingTransaction` | Eindeutige Kennung dieser Anfrage (für spätere Buchung) |
+| `userGuid` | Kennung des anfragenden Fahrgasts |
+| `successful` | War die Anfrage grundsätzlich erfolgreich? |
+| `proposals[]` | Liste konkreter Fahrvorschläge (kann leer sein) |
+| `statusCode` | Strukturierte Statusinformation, falls keine oder eingeschränkte Vorschläge |
+
+Ein **Vorschlag** (Proposal) enthält die geplante Abhol- und
+Ankunftszeit, das vorgeschlagene Fahrzeug, die Kosten und die
+Gültigkeitsdauer.
+
+## Statuscodes der Fahrtanfrage
+
+Der `statusCode` im Antwortobjekt kennzeichnet — auch bei
+HTTP-Erfolg — die fachliche Lage:
+
+- **Successful** — Anfrage erfolgreich, Vorschläge enthalten
+- **NoValidCabs** — kein Fahrzeug verfügbar (leere Flotte oder außerhalb
+  Schichtplan)
+- **StartOutsideServiceArea** — Startort liegt außerhalb des Betriebsgebiets
+- **DropoffOutsideServiceArea** — Zielort liegt außerhalb des Betriebsgebiets
+- **RouteNotPossible** — keine fahrbare Route zwischen Start und Ziel
+- **DropOffTimeNotPossible** — gewünschte Ankunftszeit nicht erreichbar
+- **StartLocationNotPossible** — Startort konnte nicht auf einen
+  fahrbaren Punkt korrigiert werden
+- **DropoffLocationNotPossible** — Zielort konnte nicht auf einen
+  fahrbaren Punkt korrigiert werden
+- **RequestTooEarly** — Anfrage liegt zu früh in der Vergangenheit oder
+  noch außerhalb des Planungshorizonts

--- a/reisewitz-test/README.md
+++ b/reisewitz-test/README.md
@@ -11,15 +11,23 @@ definierten Betriebsgebiet. Fahrgäste senden Fahrtanfragen, das System
 schlägt verfügbare Fahrzeuge mit Abhol- und Ankunftszeiten vor, und
 bucht die Fahrt nach Auswahl.
 
+Im Einsatz sind zwei Fahrzeugklassen, die in der Regel im Verbund
+arbeiten: kleine, **elektrisch betriebene Cabs** für die
+Personenbeförderung, und größere **Zugfahrzeuge ("Pros") mit
+Wasserstoff-Antrieb**. Auf längeren Strecken werden Cabs per Kupplung
+an ein Pro angehängt — sie sparen so eigene Akkukapazität und werden
+über dieselbe Kupplung während der Fahrt aufgeladen. Auf der ersten
+und letzten Meile fahren die Cabs eigenständig.
+
 ## Begriffe
 
 | Begriff | Bedeutung |
 |---|---|
 | **OperationArea** (Betriebsgebiet) | Geografisch begrenztes Polygon, innerhalb dessen Fahrten möglich sind |
 | **AccessPoint** (Einstiegspunkt) | Fest definierter Ein- und Ausstiegsort innerhalb des Betriebsgebiets (z. B. Hauptbahnhof, Universität) |
-| **Cab** | Fahrgast-Fahrzeug (Personenbeförderung). Fährt einzeln oder gekoppelt mit einem Pro |
-| **Pro** | Großes Trägerfahrzeug, das mehrere Cabs auf längeren Strecken im Konvoi mitnehmen kann |
-| **ChainingLocation** (Kopplungsort) | Ort, an dem ein Cab an ein Pro angekoppelt oder davon getrennt wird |
+| **Cab** | Elektrisch betriebenes Fahrgast-Fahrzeug (Personenbeförderung). Fährt einzeln oder per Kupplung an ein Pro angehängt |
+| **Pro** | Wasserstoff-betriebenes Zugfahrzeug. Auf längeren Strecken werden mehrere Cabs per Kupplung an das Pro angehängt; über dieselbe Kupplung wird der Cab-Akku während der Fahrt geladen |
+| **ChainingLocation** (Kopplungsort) | Ort, an dem ein Cab per Kupplung an ein Pro angehängt oder von ihm wieder gelöst wird |
 | **ParkingLocation** (Parkplatz) | Wartepunkt für Fahrzeuge zwischen zwei Aufträgen |
 | **ChargingPoint** (Ladepunkt) | Ladesäule für Fahrzeuge |
 | **ChargingPointAssignment** (Ladebelegung) | Reservierung einer Ladesäule durch ein Fahrzeug für einen Zeitraum |

--- a/reisewitz-test/README.md
+++ b/reisewitz-test/README.md
@@ -1,0 +1,72 @@
+# Testfall-Dokumentation
+
+Dieser Ordner enthält die fachliche Beschreibung aller automatisierten
+Testfälle für das System. Die Dokumentation ist eigenständig: jeder
+Testfall lässt sich ohne weitere Quellen verstehen.
+
+## Domäne
+
+Das System plant und vermittelt **autonome On-Demand-Fahrten** in einem
+definierten Betriebsgebiet. Fahrgäste senden Fahrtanfragen, das System
+schlägt verfügbare Fahrzeuge mit Abhol- und Ankunftszeiten vor, und
+bucht die Fahrt nach Auswahl.
+
+## Begriffe
+
+| Begriff | Bedeutung |
+|---|---|
+| **OperationArea** (Betriebsgebiet) | Geografisch begrenztes Polygon, innerhalb dessen Fahrten möglich sind |
+| **AccessPoint** (Einstiegspunkt) | Fest definierter Ein- und Ausstiegsort innerhalb des Betriebsgebiets (z. B. Hauptbahnhof, Universität) |
+| **Cab** | Fahrgast-Fahrzeug (Personenbeförderung). Fährt einzeln oder gekoppelt mit einem Pro |
+| **Pro** | Großes Trägerfahrzeug, das mehrere Cabs auf längeren Strecken im Konvoi mitnehmen kann |
+| **ChainingLocation** (Kopplungsort) | Ort, an dem ein Cab an ein Pro angekoppelt oder davon getrennt wird |
+| **ParkingLocation** (Parkplatz) | Wartepunkt für Fahrzeuge zwischen zwei Aufträgen |
+| **ChargingPoint** (Ladepunkt) | Ladesäule für Fahrzeuge |
+| **ChargingPointAssignment** (Ladebelegung) | Reservierung einer Ladesäule durch ein Fahrzeug für einen Zeitraum |
+| **VehicleTypeSetting** (Fahrzeugtyp-Einstellung) | Stammdaten-Eintrag, der Routing-Optionen für einen Fahrzeugtyp festhält |
+| **PlanningConfiguration** (Planungskonfiguration) | Globale Parameter des Optimierers (Toleranzen, Vorschlagsanzahl etc.) |
+| **TripRequest** (Fahrtanfrage) | Anfrage eines Fahrgasts mit Start, Ziel und Zeitfenster |
+| **Proposal** (Angebot) | Konkreter Fahrtvorschlag, den der Fahrgast buchen kann |
+
+## Aufbau der Dokumentation
+
+Die Testfälle sind nach ihrem fachlichen Bereich gruppiert. Alle Tests
+laufen vollständig automatisiert über REST-Schnittstellen.
+
+| Bereich | Inhalt |
+|---|---|
+| [01 – Stammdaten](01-stammdaten/) | CRUD-Tests für die statischen Domänenobjekte (Einstiegspunkte, Kopplungsorte, Parkplätze, Fahrzeugtypen, Planungskonfiguration, Betriebsgebiet) |
+| [02 – Fahrzeuge und Laden](02-fahrzeuge-und-laden/) | CRUD-Tests für Cabs, Pros, Ladepunkte und Ladebelegungen |
+| [03 – Fahrtanfragen](03-fahrtanfragen/) | End-to-End-Tests des Buchungsflusses: Positivfälle, Konvoi-Sonderfall, Fehlerfälle (kein Cab verfügbar, außerhalb Betriebsgebiet, Zeitkonflikt, ungültige Koordinaten) |
+
+## Notation
+
+Jeder Testfall ist im **Gherkin-Format** beschrieben (Given/When/Then,
+in deutscher Sprache: Angenommen/Wenn/Dann). Schritte werden auf der
+fachlichen Ebene formuliert; technische Details (HTTP-Statuscodes,
+Endpunkt-Pfade) erscheinen nur, wo sie für die Verifikation des
+erwarteten Verhaltens unerlässlich sind.
+
+Ein typischer Testfall hat folgende Struktur:
+
+```gherkin
+Funktionalität: <Beschreibung des Verhaltens>
+
+  Hintergrund:
+    Angenommen <Vorbedingung>
+    Und <weitere Vorbedingung>
+
+  Szenario: <konkreter Fall>
+    Wenn <Aktion>
+    Dann <erwartetes Ergebnis>
+```
+
+## Konventionen
+
+- **Positiv-Tests** prüfen den erfolgreichen Pfad (gewünschtes Ergebnis bei
+  korrekten Eingaben).
+- **Negativ-Tests** prüfen die Reaktion auf falsche Eingaben oder
+  unmögliche Anforderungen (z. B. ein Fahrgast außerhalb des
+  Betriebsgebiets).
+- **Bekannte Einschränkungen** sind im jeweiligen Testfall im Abschnitt
+  „Bemerkungen" dokumentiert.

--- a/tests/Buchung_001.md
+++ b/tests/Buchung_001.md
@@ -1,0 +1,33 @@
+```
+Szenario-ID: Buchung_001
+Titel: Buchungsanfrage eines Cabs (Happy Path/Baseline)
+Ziel/Nutzen: Grundlegende Funktionalität ohne Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- mindestens ein Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichen gefüllt)
+Testdaten:
+- Eingaben:
+    - Startort: Stadtzentrum Paderborn: 51.717931844437274, 8.758447466498541
+    - Zielort: SICP: 52.72980000, 8.75335000
+    - Gewünschte Ankunftszeit: now + 5h
+- Erwartete Ausgaben/Seitenwirkungen:
+    - mindestens ein Routenvorschlag 
+Schritte (Given/When/Then):
+    -  Given alle Services laufen
+    -  And Die operative Planung hat Planungsdaten die eine Buchung erlauben
+    -  And Cabs existieren im System
+    -  And Kunde hat valide Zahlungsinformationen
+    -  When der Nutzer eine Fahrt für eine Person und ein Cab bucht
+    -  Then soll die operative Planung Vorschläge schicken
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+- [ ] …
+  Owner: FF | Reviewer: -
+```

--- a/tests/Buchung_001.md
+++ b/tests/Buchung_001.md
@@ -5,7 +5,7 @@ Ziel/Nutzen: Grundlegende Funktionalität ohne Störfaktoren
 Risiko: Mittel  | Priorität: P2
 Akteure/Rollen: Nutzer, Operative Planung, Plattform
 Voraussetzungen (Preconditions):
-- mindestens ein Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichen gefüllt)
+- mindestens ein Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichend gefüllt)
 Testdaten:
 - Eingaben:
     - Startort: Stadtzentrum Paderborn: 51.717931844437274, 8.758447466498541

--- a/tests/Buchung_002.md
+++ b/tests/Buchung_002.md
@@ -1,0 +1,52 @@
+```
+Szenario-ID: Buchung_002
+Titel: Buchungsanfrage eines Cabs (Happy Path/Baseline)
+Ziel/Nutzen: Grundlegende Funktionalität ohne Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- mindestens ein Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichend gefüllt)
+- mindestens ein TripProposal ist vorhanden:
+    {
+      "user" : "urn:ngsi-ld:User:11ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "request" : "urn:ngsi-ld:TripRequest:21ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "pickupLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 51.717931844437274, 8.758447466498541 ]
+      },
+      "dropoffLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 52.72980000, 8.75335000 ]
+      },
+      "id" : "urn:ngsi-ld:TripProposal:16ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "pickupTime" : "2025-11-11T10:18:16Z",
+      "targetTime" : "2025-11-11T10:18:16Z",
+      "costs" : 1.5,
+      "proposalReleaseTime" : "2025-11-11T10:18:16Z",
+      "type" : "TripProposal"
+    }
+Testdaten:
+- Eingaben:
+- Erwartete Ausgaben/Seitenwirkungen:
+    - ein Fahrt wird angelegt
+Schritte (Given/When/Then):
+    -  Given alle Services laufen
+    -  And Die operative Planung hat Planungsdaten die eine Buchung erlauben
+    -  And Cabs existieren im System
+    -  And Kunde hat valide Zahlungsinformationen
+    -  When der Nutzer Fahrtvorschläge bekommt
+    -  Then soll der Nutzer eine Fahrt anlegen können
+    -  And soll die Operative Planung informiert werden
+    -  And soll der Payment Service informiert werden
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+    - Erstellte Fahrt gleicht dem Proposal
+    - Erstellte Fahrt ist im Status Unplanned und ohne Fahrtzeugbindung
+  Owner: FF | Reviewer: -
+```

--- a/tests/Buchung_003.md
+++ b/tests/Buchung_003.md
@@ -1,0 +1,57 @@
+```
+Szenario-ID: Buchung_003
+Titel: Buchungsanfrage eines Cabs (Happy Path/Baseline)
+Ziel/Nutzen: Grundlegende Funktionalität ohne Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- mindestens ein Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichend gefüllt)
+- mindestens ein Trip ist vorhanden:
+    {
+      "user" : "urn:ngsi-ld:User:11ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "pickupLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 51.717931844437274, 8.758447466498541 ]
+      },
+      "dropoffLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 52.72980000, 8.75335000 ]
+      },
+      "personalPreferences" : {
+        "allowCarpooling" : false,
+        "toleratedDelayBefore" : 1,
+        "toleratedDelayAfter" : 1
+      },
+      "id" : "urn:ngsi-ld:Trip:16ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "type" : "Trip",
+      "pickupTime" : "2025-11-11T10:18:16Z",
+      "targetTime" : "2025-11-11T10:18:16Z",
+      "skills" : [],
+      "requestedAdults" : 1,
+      "requestedChilds" : 1,
+      "luggage" : 1,
+      "status" : "Unplanned"
+    }
+Testdaten:
+- Eingaben:
+- Erwartete Ausgaben/Seitenwirkungen:
+    - für Fahrt wird eine Zahlung freigegeben
+Schritte (Given/When/Then):
+    -  Given alle Services laufen
+    -  And Die operative Planung hat Planungsdaten die eine Buchung erlauben
+    -  And Cabs existieren im System
+    -  And Kunde hat valide Zahlungsinformationen
+    -  When der Nutzer eine Fahrt erstellt
+    -  Then soll der Payment Service informiert werden
+    -  And soll der Payment Service die Fahrt frei geben
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+    - Erstellte Fahrt hat Feld "payment" : "Permitted"
+  Owner: FF | Reviewer: -
+```

--- a/tests/Buchung_004.md
+++ b/tests/Buchung_004.md
@@ -1,0 +1,57 @@
+```
+Szenario-ID: Buchung_004
+Titel: Buchungsanfrage eines Cabs (Happy Path/Baseline)
+Ziel/Nutzen: Grundlegende Funktionalität ohne Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- mindestens ein Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichend gefüllt)
+- mindestens ein Trip ist vorhanden:
+    {
+      "user" : "urn:ngsi-ld:User:11ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "pickupLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 51.717931844437274, 8.758447466498541 ]
+      },
+      "dropoffLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 52.72980000, 8.75335000 ]
+      },
+      "personalPreferences" : {
+        "allowCarpooling" : false,
+        "toleratedDelayBefore" : 1,
+        "toleratedDelayAfter" : 1
+      },
+      "id" : "urn:ngsi-ld:Trip:16ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "type" : "Trip",
+      "pickupTime" : "2025-11-11T10:18:16Z",
+      "targetTime" : "2025-11-11T10:18:16Z",
+      "skills" : [],
+      "requestedAdults" : 1,
+      "requestedChilds" : 1,
+      "luggage" : 1,
+      "status" : "Unplanned",
+      "payment" : "Permitted"
+    }
+Testdaten:
+- Eingaben:
+- Erwartete Ausgaben/Seitenwirkungen:
+    - für Fahrt wird bestätigt
+Schritte (Given/When/Then):
+    -  Given alle Services laufen
+    -  And Die operative Planung hat Planungsdaten die eine Buchung erlauben
+    -  And Cabs existieren im System
+    -  And Kunde hat valide Zahlungsinformationen
+    -  When die Operative Planung einen Trip erhält
+    -  Then die Operative Planung den Trip frei geben
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+    - Erstellte Fahrt hat Feld "status" : "Planned"
+  Owner: FF | Reviewer: -
+```

--- a/tests/Buchung_005.md
+++ b/tests/Buchung_005.md
@@ -1,0 +1,57 @@
+```
+Szenario-ID: Buchung_003
+Titel: Buchungsanfrage eines Cabs (Fehlerfall fehlende Zahlungsinformationen)
+Ziel/Nutzen: Abweichungen vom Happy Path testen
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- mindestens ein Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichend gefüllt)
+- mindestens ein Trip ist vorhanden:
+    {
+      "user" : "urn:ngsi-ld:User:11ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "pickupLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 51.717931844437274, 8.758447466498541 ]
+      },
+      "dropoffLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 52.72980000, 8.75335000 ]
+      },
+      "personalPreferences" : {
+        "allowCarpooling" : false,
+        "toleratedDelayBefore" : 1,
+        "toleratedDelayAfter" : 1
+      },
+      "id" : "urn:ngsi-ld:Trip:16ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "type" : "Trip",
+      "pickupTime" : "2025-11-11T10:18:16Z",
+      "targetTime" : "2025-11-11T10:18:16Z",
+      "skills" : [],
+      "requestedAdults" : 1,
+      "requestedChilds" : 1,
+      "luggage" : 1,
+      "status" : "Unplanned"
+    }
+Testdaten:
+- Eingaben:
+- Erwartete Ausgaben/Seitenwirkungen:
+    - für Fahrt wird eine Zahlung nicht freigegeben
+Schritte (Given/When/Then):
+    -  Given alle Services laufen
+    -  And Die operative Planung hat Planungsdaten die eine Buchung erlauben
+    -  And Cabs existieren im System
+    -  ~~And Kunde hat valide Zahlungsinformationen~~
+    -  When der Nutzer eine Fahrt erstellt
+    -  Then soll der Payment Service informiert werden
+    -  And soll der Payment Service die Fahrt frei geben
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+    - Erstellte Fahrt hat Feld "payment" : "Denied"
+  Owner: FF | Reviewer: -
+```

--- a/tests/CabOmission_01.md
+++ b/tests/CabOmission_01.md
@@ -1,0 +1,29 @@
+Szenario-ID: CabOmission_01
+Titel: Cab fällt aus und wird ersetzt
+Ziel/Nutzen: Fehlerbehandlung bei Problemem im Fahrplan
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- mindestens ein weiteres Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichend gefüllt)
+Testdaten:
+- Eingaben:
+    - Benachrichtigung über Ausfall des ursprünglich geplanten Cabs
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Vorschlag für ein anderes Cab, das den Termin einhalten kann 
+Schritte (Given/When/Then):
+    - Given alle Services laufen
+    - And Die operative Planung hat Planungsdaten die eine Buchung erlauben
+    - And Cabs existieren im System
+    - When das geplante Cab den Termin aufgrund von Problemen nicht einhalten kann
+    - Then Operative Planung stellt intern neue Terminanfrage für den bestehenden Termin
+    - And Operative Planung ändert die Fahrpläne, so dass ein anderes Cab den Termin übernehmen kann (interne neue Buchung)
+    - And Cabs werden über Änderungen ihrer Fahrpläne informiert
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+- Alle Termine können mit verändertem Fahrplan eingehalten werden

--- a/tests/CabOmission_02.md
+++ b/tests/CabOmission_02.md
@@ -1,0 +1,31 @@
+Szenario-ID: CabOmission_02
+Titel: Cab fällt aus und Fahrt verspätet sich
+Ziel/Nutzen: Fehlerbehandlung bei Problemem im Fahrplan
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- mindestens ein weiteres Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichend gefüllt)
+Testdaten:
+- Eingaben:
+    - Benachrichtigung über Ausfall des ursprünglich geplanten Cabs
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Vorschlag für ein anderes Cab, das den Termin mit Verspätung einhalten kann 
+Schritte (Given/When/Then):
+    - Given alle Services laufen
+    - And Die operative Planung hat Planungsdaten die eine Buchung erlauben
+    - And Cabs existieren im System
+    - When das geplante Cab den Termin aufgrund von Problemen nicht einhalten kann
+    - Then Operative Planung stellt intern neue Terminanfrage für den bestehenden Termin
+    - And Operative Planung ändert die Fahrpläne, so dass ein anderes Cab den Termin mit Verspätung übernehmen kann (interne neue Buchung)
+    - And Cabs werden über Änderungen ihrer Fahrpläne informiert
+    - And Nutzer wird über Verspätung informiert
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+- Fahrt kann mit Verspätung durchgeführt werden   
+- Alle anderen Termine können mit verändertem Fahrplan eingehalten werden

--- a/tests/CabOmission_03.md
+++ b/tests/CabOmission_03.md
@@ -1,0 +1,33 @@
+Szenario-ID: CabOmission_03
+Titel: Cab fällt aus und Fahrt kann nicht durchgeführt werden
+Ziel/Nutzen: Fehlerbehandlung bei Problemem im Fahrplan
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+
+Testdaten:
+- Eingaben:
+    - Benachrichtigung über Ausfall des ursprünglich geplanten Cabs
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Storno des Auftrags 
+Schritte (Given/When/Then):
+    - Given alle Services laufen
+    - And Die operative Planung hat Planungsdaten die eine Buchung erlauben
+    - And Cabs existieren im System
+    - When das geplante Cab den Termin aufgrund von Problemen nicht einhalten kann
+    - Then Operative Planung stellt intern neue Terminanfrage für den bestehenden Termin
+    - And Operative Planung findet keinen Vorschlag
+    - And Storno des Auftrags wird ausgelöst
+    - And Fahrpläne werden angepasst
+    - And Cabs werden über Änderungen ihrer Fahrpläne informiert
+    - And Nutzer wird über Aufall informiert
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+- Fahrt wurde storniert   
+- Alle anderen Termine können mit verändertem Fahrplan eingehalten werden

--- a/tests/CabOnlyTask_001.md
+++ b/tests/CabOnlyTask_001.md
@@ -1,0 +1,27 @@
+Szenario-ID: CabOnlyTask_001
+Titel: Cab fährt zum Abholort
+Ziel/Nutzen: Cabfahrt ohne Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- Fahrpläne sind valide und Fahrzeug kann den Auftrag erfüllen
+Testdaten:
+- Eingaben:
+    - Beginn eines Fahrtauftrags laut Fahrplan
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Cab ist am Abholort
+    - Cab mit neuem Status (Akkustand, Standort) 
+Schritte (Given/When/Then):
+    - Given alle Services laufen
+    - When Abarbeitung des Auftrags muss laut Fahrplan beginnen
+    - Then Information an das Cab, wohin es fahren muss
+    - And Cab fährt zum Abholort
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+- Cab erreicht Abholort zum Terminzeitpunkt

--- a/tests/CabOnlyTask_002.md
+++ b/tests/CabOnlyTask_002.md
@@ -1,0 +1,30 @@
+Szenario-ID: CabOnlyTask_002
+Titel: Nutzer wird abgeholt ohne Störfaktoren
+Ziel/Nutzen: Cabfahrt ohne Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- Fahrpläne sind valide und Fahrzeug kann den Auftrag erfüllen
+- Cab ist am Abholort
+Testdaten:
+- Eingaben:
+    - Cab hat Abholort erreicht
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Nutzer ist im Fahrzeug
+    - Fahrtauftrag kann fortgesetzt werden 
+Schritte (Given/When/Then):
+    - Given alle Services laufen
+    - When Cab ist einstoegsbereit
+    - Then Information an den Nutzer, dass er einsteigen kann
+    - And Nutzer öffnet Tür
+    - And Nutzer steigt ein
+    - And Nutzer schließt Tür
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+- Cab ist mit Nutzer abfahrbereit

--- a/tests/CabOnlyTask_003.md
+++ b/tests/CabOnlyTask_003.md
@@ -1,0 +1,29 @@
+Szenario-ID: CabOnlyTask_003
+Titel: Nutzer wird abgeholt steigt aber nicht ein
+Ziel/Nutzen: Cabfahrt mit Störung durch Nutzer
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- Fahrpläne sind valide und Fahrzeug kann den Auftrag erfüllen
+- Cab ist am Abholort
+Testdaten:
+- Eingaben:
+    - Cab hat Abholort erreicht
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Nutzer steigt nicht ein
+    - Fahrtauftrag wird abgebrochen 
+Schritte (Given/When/Then):
+    - Given alle Services laufen
+    - When Cab ist einstiegsbereit
+    - And Nutzer reagiert nicht
+    - Then Storno des Auftrags
+    - And Anpassung der Fahrpläne
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+- Cab ist an neuem Standort einsatzbereit

--- a/tests/CabOnlyTask_004.md
+++ b/tests/CabOnlyTask_004.md
@@ -1,0 +1,31 @@
+Szenario-ID: CabOnlyTask_004
+Titel: Nutzer wird abgeholt schließt die Tür aber nicht
+Ziel/Nutzen: Cabfahrt mit Störung durch Nutzer
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- Fahrpläne sind valide und Fahrzeug kann den Auftrag erfüllen
+- Cab ist am Abholort
+Testdaten:
+- Eingaben:
+    - Cab hat Abholort erreicht
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Tür ist geöffnet
+    - Fahrtauftrag wkann icht durchgeführt werden 
+Schritte (Given/When/Then):
+    - Given alle Services laufen
+    - When Cab ist einstiegsbereit
+    - And Tür ist geöffnet
+    - Then Information an den Nutzer, Tür zu schließen
+    - And Information an Betreiber, dass Tür nicht geschlosssen wird
+    - And Cab vorläufig aus dem Fahrplan entfernt
+    - And Operative Planung passt Fahrpläne wegen Störung an
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+- Cab mit Störung nicht weiter einsatzbereit (bis die Tür geschlossen wurde)

--- a/tests/CabOnlyTask_005.md
+++ b/tests/CabOnlyTask_005.md
@@ -1,0 +1,29 @@
+Szenario-ID: CabOnlyTask_005
+Titel: Nutzer wird zum Ziel Gebracht, ohne Störfaktoren
+Ziel/Nutzen: Cabfahrt ohne Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- Fahrpläne sind valide und Fahrzeug kann den Auftrag erfüllen
+- Cab ist abfahrbereit am Abholort und Nutzer ist eingestiegen
+Testdaten:
+- Eingaben:
+    - Einstiegsprozess erfolgreich abgeschlossen
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Nutzer ist am Zielort
+    - Cab hat neuen Status (Akku, Standort) 
+Schritte (Given/When/Then):
+    - Given alle Services laufen
+    - When Cab ist abfahrbereit
+    - Then Information an das Cab, wohin es fahren soll
+    - And Cab bringt Nutzer zum Zielort
+    - And Nutzer wird über Ankunft informiert
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+- Cab und Nutzer sind am Zielort

--- a/tests/CabOnlyTask_006.md
+++ b/tests/CabOnlyTask_006.md
@@ -1,0 +1,31 @@
+Szenario-ID: CabOnlyTask_006
+Titel: Nutzer steigt aus, ohne Störfaktoren
+Ziel/Nutzen: Cabfahrt ohne Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- Fahrpläne sind valide und Fahrzeug kann den Auftrag erfüllen
+- Cab ist mit Nutzer am Ziel
+Testdaten:
+- Eingaben:
+    - Cab meldet Ankunft am Zielort
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Cab ist für nächsten Auftrag einsatzbereit 
+Schritte (Given/When/Then):
+    - Given alle Services laufen
+    - When Cab ist am Zielort
+    - Then Information an den Nutzer, auszusteigen
+    - And Nutzer öffnet Tür
+    - And Nutzer steigt aus
+    - And Nutzer schließt Tür
+    - And Oprative Planung prüft, ob der Fahrzeugzustand valide ist (können die Folgeaufträge weiter eingehalten werden?)
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+- Cab und Nutzer sind am Zielort
+- Cab ist wieder einsatzbereit

--- a/tests/CabOnlyTask_007.md
+++ b/tests/CabOnlyTask_007.md
@@ -1,0 +1,32 @@
+Szenario-ID: CabOnlyTask_007
+Titel: Nutzer steigt aus, mit Störfaktoren
+Ziel/Nutzen: Cabfahrt mit Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- Fahrpläne sind valide und Fahrzeug kann den Auftrag erfüllen
+- Cab ist mit Nutzer am Ziel
+Testdaten:
+- Eingaben:
+    - Cab meldet Ankunft am Zielort
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Cab hat Störung 
+Schritte (Given/When/Then):
+    - Given alle Services laufen
+    - When Cab ist am Zielort
+    - And Nutzer schließt Austieg nicht ab (bleibt sitzen oder schließt Tür nicht wieder)
+    - Then Information an den Nutzer, Problem  zu beheben
+    - And Information an den Betreiber über Störung
+    - And Cab vorläufig aus dem Fahrplan entfernt
+    - And Operative Planung passt Fahrpläne wegen Störung an
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+- Cab hat Störung
+- Fahrpläne sind angepasst
+- Andere Aufträge können erfüllt werden oder werden storniert

--- a/tests/Stornierung_001.md
+++ b/tests/Stornierung_001.md
@@ -1,0 +1,60 @@
+```
+Szenario-ID: Stornierung_001
+Titel: Stornierung einer Fahrt bevor Fahrzeug geschickt wird
+Ziel/Nutzen: Grundlegende Funktionalität ohne Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- mindestens ein Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichend gefüllt)
+- mindestens ein Trip ist vorhanden:
+    {
+      "user" : "urn:ngsi-ld:User:11ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "pickupLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 51.717931844437274, 8.758447466498541 ]
+      },
+      "dropoffLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 52.72980000, 8.75335000 ]
+      },
+      "personalPreferences" : {
+        "allowCarpooling" : false,
+        "toleratedDelayBefore" : 1,
+        "toleratedDelayAfter" : 1
+      },
+      "id" : "urn:ngsi-ld:Trip:16ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "type" : "Trip",
+      "pickupTime" : "2025-11-11T10:18:16Z",
+      "targetTime" : "2025-11-11T10:18:16Z",
+      "skills" : [],
+      "requestedAdults" : 1,
+      "requestedChilds" : 1,
+      "luggage" : 1,
+      "status" : "Planned",
+      "payment" : "Permitted"
+    }
+Testdaten:
+- Eingaben:
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Fahrt wird storniert
+    - Kein Fahrzeug wird zugeordnet
+    - Payment Service wird informiert
+Schritte (Given/When/Then):
+    -  Given alle Services laufen
+    -  And Trip existiert und wurde durch die operative Planung bestätigt
+    -  And Cabs existieren im System
+    -  When der Nutzer seinen Trip abwählt
+    -  Then der Status des Trips geändert wird
+    -  And kein Fahrzeug dem Trip zugeordnet wird
+    -  And der Payment Service eine Information erhält und gegenebenfalls einen Preis fest legt
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+    - Erstellte Fahrt hat Feld "status" : "Canceled"
+  Owner: FF | Reviewer: -
+```

--- a/tests/Stornierung_002.md
+++ b/tests/Stornierung_002.md
@@ -1,0 +1,62 @@
+```
+Szenario-ID: Stornierung_002
+Titel: Stornierung einer Fahrt wenn Fahrzeug auf dem Weg zum Kunden ist
+Ziel/Nutzen: Grundlegende Funktionalität ohne Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- mindestens ein Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichend gefüllt)
+- mindestens ein Trip ist vorhanden:
+    {
+      "user" : "urn:ngsi-ld:User:11ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "pickupLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 51.717931844437274, 8.758447466498541 ]
+      },
+      "dropoffLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 52.72980000, 8.75335000 ]
+      },
+      "personalPreferences" : {
+        "allowCarpooling" : false,
+        "toleratedDelayBefore" : 1,
+        "toleratedDelayAfter" : 1
+      },
+      "id" : "urn:ngsi-ld:Trip:16ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "type" : "Trip",
+      "pickupTime" : "2025-11-11T10:18:16Z",
+      "targetTime" : "2025-11-11T10:18:16Z",
+      "skills" : [],
+      "vehicle": "urn:ngsi-ld:vehicle:cab0001",
+      "requestedAdults" : 1,
+      "requestedChilds" : 1,
+      "luggage" : 1,
+      "status" : "Planned",
+      "payment" : "Permitted"
+    }
+Testdaten:
+- Eingaben:
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Fahrt wird storniert
+    - Fahrzeug erhält neue Zielinformation
+    - Payment Service wird informiert
+Schritte (Given/When/Then):
+    -  Given alle Services laufen
+    -  And Trip existiert und wurde durch die operative Planung bestätigt
+    -  And Cabs existieren im System
+    -  When der Nutzer seinen Trip abwählt
+    -  Then der Status des Trips geändert wird
+    -  And Fahrzeug aus dem Trip entfernt wird
+    -  And Fahrzeug neue Zielkoordinaten erhält
+    -  And der Payment Service eine Information erhält und gegenebenfalls einen Preis fest legt
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+    - Erstellte Fahrt hat Feld "status" : "Canceled"
+  Owner: FF | Reviewer: -
+```

--- a/tests/Stornierung_003.md
+++ b/tests/Stornierung_003.md
@@ -1,0 +1,66 @@
+```
+Szenario-ID: Stornierung_003
+Titel: Stornierung einer Fahrt wenn Kunde im Fahrzeug sitzt
+Ziel/Nutzen: Grundlegende Funktionalität ohne Störfaktoren
+Risiko: Mittel  | Priorität: P2
+Akteure/Rollen: Nutzer, Operative Planung, Plattform
+Voraussetzungen (Preconditions):
+- mindestens ein Cab steht im Gebiet zur Verfügung (ohne Fahrauftrag, Batterie ausreichend gefüllt)
+- mindestens ein Trip ist vorhanden:
+    {
+      "user" : "urn:ngsi-ld:User:11ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "pickupLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 51.717931844437274, 8.758447466498541 ]
+      },
+      "dropoffLocation" : {
+        "type" : "Point",
+        "coordinates" : [ 52.72980000, 8.75335000 ]
+      },
+      "personalPreferences" : {
+        "allowCarpooling" : false,
+        "toleratedDelayBefore" : 1,
+        "toleratedDelayAfter" : 1
+      },
+      "id" : "urn:ngsi-ld:Trip:16ea1c5c-5aa6-11e3-8244-4b82063ca31c",
+      "type" : "Trip",
+      "pickupTime" : "2025-11-11T10:18:16Z",
+      "targetTime" : "2025-11-11T10:18:16Z",
+      "skills" : [],
+      "vehicle": "urn:ngsi-ld:vehicle:cab0001",
+      "requestedAdults" : 1,
+      "requestedChilds" : 1,
+      "luggage" : 1,
+      "status" : "Planned",
+      "payment" : "Permitted"
+    }
+- Nutzer hat Fahrt angetreten
+Testdaten:
+- Eingaben:
+- Erwartete Ausgaben/Seitenwirkungen:
+    - Fahrt wird storniert
+    - Fahrzeug erhält neue Zielinformation
+    - Fahrzeug lässt Nutzer aussteigen
+    - Payment Service wird informiert
+Schritte (Given/When/Then):
+    -  Given alle Services laufen
+    -  And Trip existiert und wurde durch die operative Planung bestätigt
+    -  And Cabs existieren im System
+    -  And der Nutzer die Fahrt angetreten hat
+    -  When der Nutzer seinen Trip abwählt
+    -  Then der Status des Trips geändert wird
+    -  And Fahrzeug neue Zielkoordinaten erhält
+    -  And das Fahrzeug den Nutzer aussteigen lässt
+    -  And der Payment Service eine Information erhält und gegenebenfalls einen Preis fest legt
+Nicht-funktionale Kriterien:
+- Leistung: Antwort in unter 3 sec
+- Zuverlässigkeit: -
+  Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+  Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+  Akzeptanzkriterien (Abnahme-Checkliste):
+    - Erstellte Fahrt hat Feld "status" : "Canceled"
+    - Fahrzeug hält an
+  Owner: FF | Reviewer: -
+```

--- a/tests/Template.md
+++ b/tests/Template.md
@@ -1,0 +1,35 @@
+```
+Szenario-ID: <FeatureID>
+Titel: <kurz & ansprechend>
+Ziel/Nutzen: <warum testen wir das?>
+Risiko: <hoch/mittel/niedrig>  | Priorität: <P1–P3>
+Akteure/Rollen: <User, System, externe Dienste>
+Voraussetzungen (Preconditions):
+- <Systemzustand, Rechte, Feature Flags, Datenstände>
+
+Testdaten:
+- Eingaben: <konkrete Werte oder Datengenerator/Fixture>
+- Erwartete Ausgaben/Seitenwirkungen: <…>
+
+Schritte (Given/When/Then):
+- Given …
+- And …
+- When …
+- Then …
+
+Nicht-funktionale Kriterien:
+- Leistung: <z. B. ≤ 500 ms @ n=50>
+- Sicherheit/Compliance: <z. B. OIDC-Fluss gültig, PII maskiert>
+- Zuverlässigkeit: <Retries, Idempotenz>
+
+Abhängigkeiten/Mocks:
+- <Endpunkte, Zertifikate, Queues, Zeitabhängigkeiten>
+
+Messung/Telemetrie:
+- <Logs, Metriken, Traces, Check-IDs>
+
+Akzeptanzkriterien (Abnahme-Checkliste):
+- [ ] …
+
+Owner: <Name/Team> | Reviewer: <Name>
+```


### PR DESCRIPTION
Testplan reisewitz: 
Initiales hinzufügen der Testfälle von reisewitz (interne Tests, die nur die operative Planung zum Ziel haben)
Dokumentiert und durchgeführt von reisewitz